### PR TITLE
Add slack integration to post test report on slack channel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,11 +23,13 @@ e) Get setup with your browser driver. If you don't know how to, please try:
 
    > For Chrome: https://sites.google.com/a/chromium.org/chromedriver/getting-started
 
-   > For Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver #Note: Check firefox version & selenium version compatibility before downloading geckodriver.
+   > For Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver	#Note: Check firefox version & selenium version compatibility before downloading geckodriver.
 
 f) [ADVANCED and OPTIONAL] Update 'conf/remote_credentials.py' if you want to run on BrowserStack/Sauce Labs
 
 g) [ADVANCED and OPTIONAL] In case you have TestRail Integration update the 'conf/testrail.conf' with proper case ids. Also update the 'conf/testrail.env' with url,user,password.
+
+h) [ADVANCED and OPTIONAL] Refer 'utils/post_test_reports_to_slack.py'and add slack incoming webhook url if you want to post the test reports on Slack channel.
 
 
 __If your setup goes well__, you should be to run a simple test with this command:
@@ -55,7 +57,7 @@ a) Directory structure of our current Templates
 
 	|__tests: Put your tests in here
 
-	|__utils: All utility modules (email_util,TestRail, BrowserStack, Base Logger) are kept in this folder
+	|__utils: All utility modules (email_util,TestRail, BrowserStack, Base Logger, post_test_reports_to_slack) are kept in this folder
 	
 
 ---------------------------
@@ -66,12 +68,13 @@ a)py.test [options]
 
 	-s	used to display the output on the screen			E.g: py.test -s (This will run all the tests in the directory and subdirectories)
 	-U  	used to run against specific URL				E.g: py.test -U http://YOUR_localhost_URL (This will run against your local instance)
-	-M  	used to run tests on Browserstack/Sauce Lab		E.g: py.test -s -M Y -U https://qxf2.com	
+	-M  	used to run tests on Browserstack/Sauce Lab			E.g: py.test -s -M Y -U https://qxf2.com	
 	-B all	used to run the test against multiple browser 			E.g: py.test -B all(This will run each test against the list of browsers specified in the conftest.py file,firefox and chrome in our case)
 	-V/-O	used to run against different browser versions/os versions	E.g: py.test -V 44 -O 8 (This will run each test 4 times in different browser version(default=45 & 44) and OS(default=7 & 8) combination)
 	-h	help for more options 						E.g: py.test -h
 	-k      used to run tests which match the given substring expresion 	E.g: py.test -k table  (This will trigger test_example_table.py test)
-	
+	-I	used to post pytest reports on the Slack channel		E.g: py.test -I Y -v > log/pytest_report.log
+	-n 	used to run tests in parallel					E.g: py.test -n 3 -v (This will run three tests in parallel)
 
 b)python tests/test_example_form.py (can also be used to run standalone test) 	
 

--- a/conftest.py
+++ b/conftest.py
@@ -48,7 +48,19 @@ def os_name():
 @pytest.fixture
 def os_version():
     "pytest fixture for os version"
-    return pytest.config.getoption("-O") 
+    return pytest.config.getoption("-O")
+
+
+@pytest.fixture
+def slack_flag():
+    "pytest fixture for os version"
+    return pytest.config.getoption("-I")
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus):
+    "add additional section in terminal summary reporting."
+    if pytest.config.getoption("-I").lower() == 'y':
+        post_test_reports_to_slack.post_reports_to_slack()
 
 
 def pytest_generate_tests(metafunc):
@@ -107,5 +119,9 @@ def pytest_addoption(parser):
                       action="append",
                       help="The operating system: Windows 7, Linux",
                       default=[])
+    parser.addoption("-I","--slack_flag",
+                      dest="slack_flag",
+                      default="N",
+                      help="Post the test report on slack channel: Y or N")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 from conf import browser_os_name_conf
+from utils import post_test_reports_to_slack
 
 
 @pytest.fixture

--- a/utils/post_test_reports_to_slack.py
+++ b/utils/post_test_reports_to_slack.py
@@ -1,0 +1,46 @@
+'''
+A Simple API util which used to post test reports on Slack Channel.
+
+Steps to Use:
+1. Generate Slack incoming webhook url by reffering our blog: https://qxf2.com/blog/post-pytest-test-results-on-slack/ & add url in our code
+2. Generate test report log file by adding ">log/pytest_report.log" command at end of py.test command for e.g. py.test -k example_form -I Y -r F -v > log/pytest_report.log
+Note: Your terminal must be pointed to root address of our POM while generating test report file using above command
+3. Check you are calling correct report log file or not
+'''
+import json,os,requests 
+
+def post_reports_to_slack():
+        #To generate incoming webhook url ref: https://qxf2.com/blog/post-pytest-test-results-on-slack/
+        url= "incoming webhook url"  #Add your Slack incoming webhook url here
+    
+        #To generate pytest_report.log file add ">pytest_report.log" at end of py.test command for e.g. py.test -k example_form -I Y -r F -v > log/pytest_report.log
+        test_report_file = os.path.abspath(os.path.join(os.path.dirname(__file__),'..','log','pytest_report.log'))#Change report file name & address here
+
+        with open(test_report_file, "r") as in_file:
+                testdata = ""
+                for line in in_file:
+                        testdata = testdata + '\n' + line
+                
+        # Set Slack Pass Fail bar indicator color according to test results   
+        if 'FAILED' in testdata:
+            bar_color = "#ff0000"
+        else:
+            bar_color = "#36a64f"
+
+        data = {"attachments":[
+                            {"color": bar_color,
+                            "title": "Test Report",
+                            "text": testdata}
+                            ]}
+        json_params_encoded = json.dumps(data)
+        slack_response = requests.post(url=url,data=json_params_encoded,headers={"Content-type":"application/json"})
+        if slack_response.text == 'ok':
+                print '\n Successfully posted pytest report on Slack channel'
+        else:
+                print '\n Something went wrong. Unable to post pytest report on Slack channel. Slack Response:', slack_response 
+
+        
+#---USAGE EXAMPLES
+if __name__=='__main__':
+        post_reports_to_slack()
+    


### PR DESCRIPTION
 Used pytest_terminal_summary plugin hook to call slack integration util, Added slack integration flag in option parser to enable or disable the slack integration.