### PR TITLE
Browserstack project build deatils

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -59,6 +59,18 @@ def os_version():
 
 
 @pytest.fixture
+def remote_project_name():
+    "pytest fixture for browserStack project name"
+    return pytest.config.getoption("--remote_project_name")
+
+
+@pytest.fixture
+def remote_build_name():
+    "pytest fixture for browserStack build name"
+    return pytest.config.getoption("--remote_build_name")
+
+
+@pytest.fixture
 def slack_flag():
     "pytest fixture for sending reports on slack"
     return pytest.config.getoption("-S")
@@ -191,6 +203,14 @@ def pytest_addoption(parser):
                       action="append",
                       help="The operating system: Windows 7, Linux",
                       default=[])
+    parser.addoption("--remote_project_name",
+                      dest="remote_project_name",
+                      help="The project name if its run in BrowserStack",
+                      default="N")
+    parser.addoption("--remote_build_name",
+                      dest="remote_build_name",
+                      help="The build name if its run in BrowserStack",
+                      default="N")
     parser.addoption("-S","--slack_flag",
                       dest="slack_flag",
                       default="N",

--- a/conftest.py
+++ b/conftest.py
@@ -206,11 +206,11 @@ def pytest_addoption(parser):
     parser.addoption("--remote_project_name",
                       dest="remote_project_name",
                       help="The project name if its run in BrowserStack",
-                      default="N")
+                      default=None)
     parser.addoption("--remote_build_name",
                       dest="remote_build_name",
                       help="The build name if its run in BrowserStack",
-                      default="N")
+                      default=None)
     parser.addoption("-S","--slack_flag",
                       dest="slack_flag",
                       default="N",

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -88,11 +88,11 @@ class Base_Page(Borg,unittest.TestCase):
         self.__class__ = PageFactory.PageFactory.get_page_object(page_name,base_url=self.base_url).__class__
        
 
-    def register_driver(self,remote_flag,os_name,os_version,browser,browser_version):
+    def register_driver(self,remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name):
         "Register the driver with Page"      
         self.set_screenshot_dir(os_name,os_version,browser,browser_version) # Create screenshot directory
         self.set_log_file()
-        self.driver = self.driver_obj.get_web_driver(remote_flag,os_name,os_version,browser,browser_version)
+        self.driver = self.driver_obj.get_web_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
         self.driver.implicitly_wait(5) 
         self.driver.maximize_window()
         

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -5,6 +5,7 @@ NOTE: Change this class as you add support for:
 2. More browsers like Opera
 """
 import dotenv,os,sys,requests,json
+from datetime import datetime
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
@@ -23,12 +24,12 @@ class DriverFactory():
         self.os_name=os_name
 
         
-    def get_web_driver(self,remote_flag,os_name,os_version,browser,browser_version):
+    def get_web_driver(self,remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name):
         "Return the appropriate driver"
         if (remote_flag.lower() == 'y'):
             try:
                 if remote_credentials.REMOTE_BROWSER_PLATFORM == 'BS':
-                    web_driver = self.run_browserstack(os_name,os_version,browser,browser_version)
+                    web_driver = self.run_browserstack(os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
                 else:
                     web_driver = self.run_sauce_lab(os_name,os_version,browser,browser_version)
                     
@@ -46,7 +47,7 @@ class DriverFactory():
         return web_driver   
     
 
-    def run_browserstack(self,os_name,os_version,browser,browser_version):
+    def run_browserstack(self,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name):
         "Run the test in browser stack when remote flag is 'Y'"
         #Get the browser stack credentials from browser stack credentials file
         USERNAME = remote_credentials.USERNAME
@@ -61,11 +62,12 @@ class DriverFactory():
             desired_capabilities = DesiredCapabilities.OPERA        
         elif browser.lower() == 'safari':
             desired_capabilities = DesiredCapabilities.SAFARI
-
         desired_capabilities['os'] = os_name
         desired_capabilities['os_version'] = os_version
         desired_capabilities['browser_version'] = browser_version
-        
+        desired_capabilities['project'] = remote_project_name
+        desired_capabilities['build'] = remote_build_name+str(datetime.now().strftime("%c"))
+
         return webdriver.Remote(RemoteConnection("http://%s:%s@hub-cloud.browserstack.com/wd/hub"%(USERNAME,PASSWORD),resolve_ip= False),
             desired_capabilities=desired_capabilities)
     

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -65,8 +65,10 @@ class DriverFactory():
         desired_capabilities['os'] = os_name
         desired_capabilities['os_version'] = os_version
         desired_capabilities['browser_version'] = browser_version
-        desired_capabilities['project'] = remote_project_name
-        desired_capabilities['build'] = remote_build_name+str(datetime.now().strftime("%c"))
+        if remote_project_name is not None:
+            desired_capabilities['project'] = remote_project_name
+        if remote_build_name is not None:
+            desired_capabilities['build'] = remote_build_name+str(datetime.now().strftime("%c"))
 
         return webdriver.Remote(RemoteConnection("http://%s:%s@hub-cloud.browserstack.com/wd/hub"%(USERNAME,PASSWORD),resolve_ip= False),
             desired_capabilities=desired_capabilities)

--- a/tests/test_example_form.py
+++ b/tests/test_example_form.py
@@ -15,7 +15,7 @@ import conf.example_form_conf as conf
 import conf.testrail_caseid_conf as testrail_file
 
 
-def test_example_form(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id):
+def test_example_form(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name):
     "Run the test"
     try:
 	#Initalize flags for tests summary
@@ -27,7 +27,7 @@ def test_example_form(base_url,browser,browser_version,os_version,os_name,remote
 
         #2. Setup and register a driver
         start_time = int(time.time())	#Set start_time with current time
-        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version)
+        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
         
         #3. Setup TestRail reporting
         if testrail_flag.lower()=='y':
@@ -161,6 +161,8 @@ if __name__=='__main__':
                         os_version=options.os_version,
                         os_name=options.os_name,
                         remote_flag=options.remote_flag,
+                        remote_project_name=options.remote_project_name,
+                        remote_build_name=options.remote_build_name,
                         testrail_flag=options.testrail_flag,
                         tesults_flag=options.tesults_flag,
                         test_run_id=options.test_run_id) 

--- a/tests/test_example_form.py
+++ b/tests/test_example_form.py
@@ -161,11 +161,11 @@ if __name__=='__main__':
                         os_version=options.os_version,
                         os_name=options.os_name,
                         remote_flag=options.remote_flag,
-                        remote_project_name=options.remote_project_name,
-                        remote_build_name=options.remote_build_name,
                         testrail_flag=options.testrail_flag,
                         tesults_flag=options.tesults_flag,
-                        test_run_id=options.test_run_id) 
+                        test_run_id=options.test_run_id,
+                        remote_project_name=options.remote_project_name,
+                        remote_build_name=options.remote_build_name) 
     else:
         print 'ERROR: Received incorrect comand line input arguments'
         print option_obj.print_usage()

--- a/tests/test_example_table.py
+++ b/tests/test_example_table.py
@@ -15,7 +15,7 @@ import conf.example_table_conf as conf
 import conf.testrail_caseid_conf as testrail_file
 
 
-def test_example_table(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id):
+def test_example_table(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name):
     "Run the test"
     try:
 	#Initalize flags for tests summary
@@ -27,7 +27,7 @@ def test_example_table(base_url,browser,browser_version,os_version,os_name,remot
 
         #2. Setup and register a driver
         start_time = int(time.time())	#Set start_time with current time
-        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version)
+        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
 
         #3. Setup TestRail reporting
         if testrail_flag.lower()=='y':
@@ -93,7 +93,9 @@ if __name__=='__main__':
                     remote_flag=options.remote_flag,
                     os_version=options.os_version,
                     browser_version=options.browser_version,
-                    os_name=options.os_name)
+                    os_name=options.os_name,
+                    remote_project_name=options.remote_project_name,
+                    remote_build_name=options.remote_build_name)
     else:
         print 'ERROR: Received incorrect input arguments'
         print options_obj.print_usage()

--- a/tests/test_successive_form_creation.py
+++ b/tests/test_successive_form_creation.py
@@ -13,7 +13,7 @@ from page_objects.PageFactory import PageFactory
 from utils.Option_Parser import Option_Parser
 import conf.successive_form_creation_conf as conf
 
-def test_succesive_form_creation(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id):
+def test_succesive_form_creation(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name):
     "Run the test"
     try:
 	#Initalize flags for tests summary
@@ -25,7 +25,7 @@ def test_succesive_form_creation(base_url,browser,browser_version,os_version,os_
 
         #2. Setup and register a driver
         start_time = int(time.time())	#Set start_time with current time
-        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version)
+        test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
 
         #3. Setup TestRail reporting
         if testrail_flag.lower()=='y':
@@ -116,7 +116,9 @@ if __name__=='__main__':
                                     remote_flag=options.remote_flag,
                                     testrail_flag=options.testrail_flag,
                                     tesults_flag=options.tesults_flag,
-                                    test_run_id=options.test_run_id)                                    
+                                    test_run_id=options.test_run_id,
+                                    remote_project_name=options.remote_project_name,
+                                    remote_build_name=options.remote_build_name)                                    
     else:
         print 'ERROR: Received incorrect comand line input arguments'
         print options_obj.print_usage()


### PR DESCRIPTION
Changes so that BrowserStack takes Project and Build details

Made the below changes
1) conftest.py: Added 2 more options remote_project_name remote_build_name for taking BS project and build name

2) Base Page: register_driver takes remote_project_name and remote_build_name, get_webdriver takes remote_project_name and remote_build_name

3) DriverFactory: import datetime to append datetime along with build name, get_webdriver takes remote_project_name and remote_build_name, run_browserstack takes remote_project_name and remote_build_name

4) GUI tests updated to take the remote_project_name and remote_build_name