### PR TITLE
Run the Mobile app test in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial < "$app_path"
+            echo "$app_path" | py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
           command: |
             echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            echo "$app_path" | py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
+            #py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
+            py.test -s -v -k mobile -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native                      
+                      
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           name: Mobile app
           command: |
             git clone https://github.com/qxf2/bitcoin-info.git
-            cd ./Bitcoin_Info/app
+            cd ./bitcoin-info/app
             app_path=`pwd`      
       - run:
           name: Decrypt remote_credentials_enc.py using openssl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
           command: |
+            cd tests
             ls -a             
             py.test -s -v /tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,24 +12,20 @@ jobs:
       - run:
           name: Mobile app
           command: |
-            git clone https://github.com/qxf2/bitcoin-info.git
-            cd ./bitcoin-info/app
-            export app_path=`pwd`
-            echo $app_path
-            #export $app_path
+            git clone https://github.com/qxf2/bitcoin-info.git           
+      - run:
+          name: Set Environment Variables
+          command: |                      
+            echo 'export app_path=/home/circleci/project/bitcoin-info/app/' >> $BASH_ENV  
       - run:
           name: Decrypt remote_credentials_enc.py using openssl
           command: |
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
-          name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
-          command: |
-            echo $app_path   
-            #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            #py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
-            py.test -s -v -k mobile -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native                      
-                      
-
+          name: Run the API, Mobile and Selenium tests
+          command: |              
+            #py.test -s -v -k mobile -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native                 
+            py.test -s -v -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native
       - store_artifacts:
           path: ./screenshots
           destination: screenshots-file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ jobs:
       - run:
           name: Mobile app
           command: |
-            git clone https://github.com/qxf2/bitcoin-info.git      
+            git clone https://github.com/qxf2/bitcoin-info.git
+            cd ./Bitcoin_Info/app
+            app_path=`pwd`      
       - run:
           name: Decrypt remote_credentials_enc.py using openssl
           command: |
@@ -20,8 +22,9 @@ jobs:
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
           command: |   
-            echo "path" > /home/circleci/project/bitcoin-info/app/           
-            py.test -s -v tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
+            #echo "path" > /home/circleci/project/bitcoin-info/app/           
+            "py.test -s -v tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native"
+
       - store_artifacts:
           path: ./screenshots
           destination: screenshots-file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ jobs:
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
-          command: |
-            py.test -s -v --ignore=./tests/test_mobile_bitcoin_price.py -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
+          command: |            
+            py.test -s -v /tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:
           path: ./screenshots
           destination: screenshots-file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ jobs:
           command: |
             pip install -r requirements.txt
       - run:
+          name: Mobile app
+          command: |
+            git clone https://github.com/qxf2/bitcoin-info.git      
+      - run:
           name: Decrypt remote_credentials_enc.py using openssl
           command: |
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
           command: |
             git clone https://github.com/qxf2/bitcoin-info.git
             cd ./bitcoin-info/app
-            app_path=`pwd`
+            export app_path=`pwd`
             echo $app_path
-            export $app_path
+            #export $app_path
       - run:
           name: Decrypt remote_credentials_enc.py using openssl
           command: |
@@ -26,7 +26,7 @@ jobs:
           command: |
             echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            "py.test -s -v tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial"
+            "py.test -s -v ./tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial"
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
           command: |   
-            ls -a             
+            echo "path" > /home/circleci/project/bitcoin-info/app           
             py.test -s -v tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,10 @@ jobs:
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
-          command: |   
+          command: |
+            echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            "py.test -s -v tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native"
+            "py.test -s -v tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial"
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            py.test -s -k mobile "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
+            py.test -s -k mobile -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial < "$app_path"
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,9 @@ jobs:
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
-          command: |
-            cd tests
+          command: |   
             ls -a             
-            py.test -s -v /tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
+            py.test -s -v tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:
           path: ./screenshots
           destination: screenshots-file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
-          command: |            
+          command: |
+            ls -a             
             py.test -s -v /tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Run the API and Selenium tests only (Ignoring to run mobile test as we are not yet set to run mobile test on server)
           command: |   
-            echo "path" > /home/circleci/project/bitcoin-info/app           
+            echo "path" > /home/circleci/project/bitcoin-info/app/           
             py.test -s -v tests/test_mobile_bitcoin_price.py '/home/circleci/project/bitcoin-info/app' -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             echo $app_path   
             #echo "path" > /home/circleci/project/bitcoin-info/app/           
-            "py.test -s -v ./tests/test_mobile_bitcoin_price.py $app_path -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial"
+            py.test -s -k mobile "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
 
       - store_artifacts:
           path: ./screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
           command: |
             git clone https://github.com/qxf2/bitcoin-info.git
             cd ./bitcoin-info/app
-            app_path=`pwd`      
+            app_path=`pwd`
+            echo $app_path
+            export $app_path
       - run:
           name: Decrypt remote_credentials_enc.py using openssl
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,7 @@ jobs:
             openssl aes-256-cbc -d -in ./conf/remote_credentials_enc.py -out ./conf/remote_credentials.py -pass env:KEY     
       - run:
           name: Run the API, Mobile and Selenium tests
-          command: |              
-            #py.test -s -v -k mobile -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native                 
+          command: |           
             py.test -s -v -N "$app_path" -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native
       - store_artifacts:
           path: ./screenshots

--- a/conftest.py
+++ b/conftest.py
@@ -258,7 +258,7 @@ def pytest_addoption(parser):
                       default="Bitcoin Info_com.dudam.rohan.bitcoininfo.apk")
     parser.addoption("-N","--app_path",
                       dest="app_path",
-                      help="Enter path location")
+                      help="Enter app path")
 
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -262,4 +262,3 @@ def pytest_addoption(parser):
 
 
 
-

--- a/conftest.py
+++ b/conftest.py
@@ -127,6 +127,11 @@ def app_name():
     "pytest fixture for app name"
     return pytest.config.getoption("-D")
 
+@pytest.fixture
+def app_path():
+    "pytest fixture for app path"
+    return pytest.config.getoption("-N")    
+
 
 def pytest_terminal_summary(terminalreporter, exitstatus):
     "add additional section in terminal summary reporting."
@@ -251,6 +256,9 @@ def pytest_addoption(parser):
                       dest="app_name",
                       help="Enter application name to be uploaded.Ex:Bitcoin Info_com.dudam.rohan.bitcoininfo.apk.",
                       default="Bitcoin Info_com.dudam.rohan.bitcoininfo.apk")
+    parser.addoption("-N","--app_path",
+                      dest="app_path",
+                      help="Enter path location")
 
 
 

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -143,8 +143,7 @@ class DriverFactory():
                     self.sauce_upload(app_path,app_name) #Saucelabs expects the app to be uploaded to Sauce storage everytime the test is run
                     #Checking if the app_name is having spaces and replacing it with blank
                     if ' ' in app_name:
-                        app_name = app_name.replace(' ','')
-                        print "The app file name is having spaces, hence replaced the white spaces with blank in the file name:%s"%app_name                                          
+                        app_name = app_name.replace(' ','')                        
                     desired_capabilities['app'] = 'sauce-storage:'+app_name
                     desired_capabilities['autoAcceptAlert']= 'true'                      
                     driver = mobile_webdriver.Remote(command_executor="http://%s:%s@ondemand.saucelabs.com:80/wd/hub"%(USERNAME,PASSWORD),
@@ -179,16 +178,25 @@ class DriverFactory():
         "Upload the apk to the sauce temperory storage"
         USERNAME = remote_credentials.USERNAME
         PASSWORD = remote_credentials.ACCESS_KEY
+        result_flag=False
         try:
             headers = {'Content-Type':'application/octet-stream'}                   
             params = os.path.join(app_path,app_name)                         
             fp = open(params,'rb')
             data = fp.read()   
-            fp.close()            
+            fp.close()
+            #Checking if the app_name is having spaces and replacing it with blank
+            if ' ' in app_name:
+                app_name = app_name.replace(' ','')
+                print "The app file name is having spaces, hence replaced the white spaces with blank in the file name:%s"%app_name                                                      
             response = requests.post('https://saucelabs.com/rest/v1/storage/%s/%s?overwrite=true'%(USERNAME,app_name),headers=headers,data=data,auth=(USERNAME,PASSWORD))
+            if response == 200:
+                result_flag=True
+                print "App successfully uploaded to sauce storage"
         except Exception as e:
             print str(e)      
 
+        return result_flag
 
     def browser_stack_upload(self,app_name,app_path):
         "Upload the apk to the BrowserStack storage if its not done earlier"

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -190,7 +190,7 @@ class DriverFactory():
                 app_name = app_name.replace(' ','')
                 print "The app file name is having spaces, hence replaced the white spaces with blank in the file name:%s"%app_name                                                      
             response = requests.post('https://saucelabs.com/rest/v1/storage/%s/%s?overwrite=true'%(USERNAME,app_name),headers=headers,data=data,auth=(USERNAME,PASSWORD))
-            if response == 200:
+            if response.status_code == 200:
                 result_flag=True
                 print "App successfully uploaded to sauce storage"
         except Exception as e:

--- a/tests/test_mobile_bitcoin_price.py
+++ b/tests/test_mobile_bitcoin_price.py
@@ -23,10 +23,7 @@ def test_mobile_bitcoin_price(mobile_os_name, mobile_os_version, device_name, ap
         actual_pass = -1
 
         #1. Create a test object.
-        test_obj = PageFactory.get_page_object("bitcoin main page")
-        
-        #Get the path of the .apk file        
-        #app_path = input('\nEnter the path of .apk file:') 
+        test_obj = PageFactory.get_page_object("bitcoin main page")      
         
         #2. Setup and register a driver
         start_time = int(time.time())

--- a/tests/test_mobile_bitcoin_price.py
+++ b/tests/test_mobile_bitcoin_price.py
@@ -15,7 +15,7 @@ import conf.mobile_bitcoin_conf as conf
 import conf.testrail_caseid_conf as testrail_file
 
 
-def test_mobile_bitcoin_price(mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, test_run_id,app_name):
+def test_mobile_bitcoin_price(mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, test_run_id,app_name,app_path):
     "Run the test."
     try:
         # Initalize flags for tests summary.
@@ -25,8 +25,8 @@ def test_mobile_bitcoin_price(mobile_os_name, mobile_os_version, device_name, ap
         #1. Create a test object.
         test_obj = PageFactory.get_page_object("bitcoin main page")
         
-        #Get the path of the .apk file
-        app_path = input('\nEnter the path of .apk file:')
+        #Get the path of the .apk file        
+        #app_path = input('\nEnter the path of .apk file:') 
         
         #2. Setup and register a driver
         start_time = int(time.time())


### PR DESCRIPTION
The goal is to run the mobile app test using BrowserStack in CircleCI. During this process encountered two issues which were fixed. 
1) One is removing user input option from the mobile test and get app_path as a conftest option and 
2) Include a check to remove spaces from the app_name in the saucec_upload method too(earlier we included this check only in run_mobile method)

Changes made in circleci/config.yml file:

* Cloned the bitcoin app in the circle config.yml 
* Setting env variable for getting the app_path in the .yml 
* Updated the pytest command to include a parameter for app_path.

Changes made in conftest.py:

* Added a new option '-N' to for getting the app_path
* Added new pytest fixture for app_path

Changes made in test_mobile_bitcoin_app.py:

* Removed the code to accept input from the user
* Added app_path parameter in the test method

Changes made to the DriverFactory.py:

* Added a check to see if the upload response status_code is 200 in sauce_upload() method and return result_flag 
* Included the condition to check for spaces in apk file in sauce_upload method also so that we upload the file without spaces

Kindly review.