### PR TITLE
decode is removed from check_cell_text_present

### DIFF
--- a/page_objects/table_object.py
+++ b/page_objects/table_object.py
@@ -97,7 +97,7 @@ class Table_Object:
             
         for row in table_text:
             for col in row:
-                if col.decode('utf-8') == text:
+                if col == text:
                     result_flag = True
                     break
             if result_flag is True:


### PR DESCRIPTION
While running test_example_table.py , saw exception as below:

Exception in method: check_cell_text_present
PYTHON SAYS: 'str' object has no attribute 'decode'

To solve this issue, decode is removed from col in check_cell_text_present.

 if col == text:
                    result_flag = True

