### PR TITLE
Changing the api_url to run api test

### DIFF
--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -16,7 +16,7 @@ from endpoints.API_Player import API_Player
 from conf import api_example_conf as conf
 
 
-def test_api_example(api_url='http://carsapi.pythonanywhere.com'):
+def test_api_example(api_url='http://35.167.62.251/'):
     "Run api test"
     try:
         # Create test object


### PR DESCRIPTION
Deployed the cars app in http://35.167.62.251/. Updated the test to point to the new server