### PR TITLE
Fixed the missing conf import for base_url

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os,pytest
 from page_objects.PageFactory import PageFactory
 from conf import browser_os_name_conf
+from conf import base_url_conf
 from utils import post_test_reports_to_slack
 from utils.email_pytest_report import Email_Pytest_Report
 from utils import Tesults
@@ -210,7 +211,7 @@ def pytest_addoption(parser):
                       help="Browser. Valid options are firefox, ie and chrome")                      
     parser.addoption("-U","--app_url",
                       dest="url",
-                      default=conf.base_url,
+                      default=base_url_conf.base_url,
                       help="The url of the application")
     parser.addoption("-A","--api_url",
                       dest="url",

--- a/page_objects/Mobile_Base_Page.py
+++ b/page_objects/Mobile_Base_Page.py
@@ -15,7 +15,7 @@ from inspect import getargspec
 from utils.BrowserStack_Library import BrowserStack_Library
 from .DriverFactory import DriverFactory
 from utils.Test_Rail import Test_Rail
-#from page_objects import PageFactory
+from page_objects import PageFactory
 
 class Borg:
     #The borg design pattern is to share state


### PR DESCRIPTION
There was a missing import in our conftest. base_url's conf was not imported in conftest.