### PR TITLE
Fixed bug in log file and screenshot directory names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,11 +7,10 @@ from utils.email_pytest_report import Email_Pytest_Report
 from utils import Tesults
 
 @pytest.fixture
-def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name):
-    
+def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name,testname):
     "Return an instance of Base Page that knows about the third party integrations"
     test_obj = PageFactory.get_page_object("Zero",base_url=base_url)
-
+    test_obj.set_calling_module(testname)
     #Setup and register a driver
     test_obj.register_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
 
@@ -59,7 +58,17 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
     #Teardown
     test_mobile_obj.wait(3)
     test_mobile_obj.teardown() 
-   
+
+
+@pytest.fixture
+def testname(request):
+    "pytest fixture for testname"
+    name_of_test = request.node.name
+    name_of_test = name_of_test.split('[')[0]
+
+    return name_of_test
+
+
 @pytest.fixture
 def browser(request):
     "pytest fixture for browser"


### PR DESCRIPTION
Fixed the incorrect log and screenshots folder name. I did this by introducing a new method to set a calling module via pytest and/or figure out test name if we do not use pytest.

There is still a bug if we run pytest on its own. We seem to be writing to both pytest.log as well as the test's own log. I know the reason. It is because our API player does not have a reset when ending itself. So both logs are alive. We can tackle that as a separate ticket since it involves changing the API player and results module.