### PR TITLE
Fix bad logic in conditional_write

### DIFF
--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -712,24 +712,20 @@ class Base_Page(Borg,unittest.TestCase):
 
 
     def conditional_write(self,flag,positive,negative,level='info'):
-        "Write out either the positive or the negative message based on flag"      
+        "Write out either the positive or the negative message based on flag"  
+        self.mini_check_counter += 1
         if level.lower() == "inverse":
-            msg = positive
             if flag is True:
-                positive = negative
                 self.write(positive,level='error')
-                self.mini_check_pass_counter += 1
             else:
-                negative = msg 
                 self.write(negative,level='info')
-                self.mini_check_counter += 1
+                self.mini_check_pass_counter += 1
         else:	        	            
             if flag is True:
                 self.write(positive,level='info')
                 self.mini_check_pass_counter += 1
             else:
-                self.write(negative,level='info')
-                self.mini_check_counter += 1
+                self.write(negative,level='error')
 
 
     def execute_javascript(self,js_script,*args):


### PR DESCRIPTION
I am solving two issues in this patch:

a) Our mini-check counter being incorrect

b) Poor logic in conditional_write. When the level is set to 'inverse' we need to treat:
*  flag=True as a failure 
* flag=False as a success. 
Luckily, we are not using 'inverse' level anywhere within our repo. So this change will not break anything.

Example of mini-checks working after fix:

![mini-check-fix](https://user-images.githubusercontent.com/4759449/71444875-d1d1de80-273a-11ea-9d27-21a60a4664d5.png)
