### PR TITLE
Removed the -V option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,7 +143,7 @@ a)py.test [options]
 	-U  	used to run against specific URL				E.g: python -m pytest -U http://YOUR_localhost_URL (This will run against your local instance)
 	-M  	used to run tests on Browserstack/Sauce Lab			E.g: python -m pytest -s -M Y -U https://qxf2.com	
 	-B all	used to run the test against multiple browser 			E.g:python -m pytest -B all(This will run each test against the list of browsers specified in the conftest.py file,firefox and chrome in our case)
-	-V/-O	used to run against different browser versions/os versions	E.g: python -m pytest -V 44 -O 8 (This will run each test 4 times in different browser version(default=45 & 44) and OS(default=7 & 8) combination)
+	--ver/-O	used to run against different browser versions/os versions	E.g: python -m pytest --ver 44 -O 8 (This will run each test 4 times in different browser version(default=45 & 44) and OS(default=7 & 8) combination)
 	-h	help for more options 						E.g: python -m pytest -h
 	-k      used to run tests which match the given substring expresion 	E.g: python -m pytest -k table  (This will trigger test_example_table.py test)
 	-S	used to post pytest reports on the Slack channel		E.g: python -m pytest -S Y -v > log/pytest_report.log

--- a/conftest.py
+++ b/conftest.py
@@ -108,7 +108,7 @@ def remote_flag(request):
 @pytest.fixture
 def browser_version(request):
     "pytest fixture for browser version"
-    return request.config.getoption("--ver") 
+    return request.config.getoption("--ver")
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -108,7 +108,7 @@ def remote_flag(request):
 @pytest.fixture
 def browser_version(request):
     "pytest fixture for browser version"
-    return request.config.getoption("-V") 
+    return request.config.getoption("--ver") 
 
 
 @pytest.fixture
@@ -275,7 +275,7 @@ def pytest_generate_tests(metafunc):
                 metafunc.parametrize("browser,browser_version,os_name,os_version", 
                                     browser_os_name_conf.default_config_list) 
             else:
-                config_list = [(metafunc.config.getoption("-B")[0],metafunc.config.getoption("-V")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
+                config_list = [(metafunc.config.getoption("-B")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
                 metafunc.parametrize("browser,browser_version,os_name,os_version", 
                                     config_list) 
         if metafunc.config.getoption("-M").lower() !='y':
@@ -321,7 +321,7 @@ def pytest_addoption(parser):
                       action="append",
                       help="The operating system: xp, 7",
                       default=[])
-    parser.addoption("-V","--ver",
+    parser.addoption("--ver",
                       dest="browser_version",
                       action="append",
                       help="The version of the browser: a whole number",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.20.0
-pytest>=5.2.0
+pytest>=5.4.0
 selenium==3.13.0
 python_dotenv==0.8.2
 Appium_Python_Client==0.28

--- a/utils/Option_Parser.py
+++ b/utils/Option_Parser.py
@@ -46,7 +46,7 @@ class Option_Parser:
                             dest="os_version",
                             help="The operating system: xp, 7",
                             default="7")
-        self.parser.add_option("-V","--ver",
+        self.parser.add_option("--ver",
                             dest="browser_version",
                             help="The version of the browser: a whole number",
                             default=45)
@@ -172,7 +172,7 @@ class Option_Parser:
                 result_flag &= True
             else:
                 result_flag = False
-                print("Browser version cannot be None. Use -V to specify a browser version")
+                print("Browser version cannot be None. Use --ver to specify a browser version")
             if options.os_name is not None:
                 result_flag &= True
             else:


### PR DESCRIPTION
First attempt at fixing the argparse error caused in pytest 5.2.2 ... I have simply upped the version of pytest in requirements.