### PR TITLE
Removed the additional method

### DIFF
--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -371,11 +371,6 @@ class Base_Page(Borg,unittest.TestCase):
         "Get the window handles"
         return self.driver.window_handles
 
-
-    def get_current_window_handle(self):
-        "Get the current window handle"
-        pass
-
     def switch_frame(self,name=None,index=None,wait_time=2):
         "switch to iframe"
         self.wait(wait_time)


### PR DESCRIPTION
Method get_current_window_handles is defined twice in Base Page. Removed the additional one which doesn't have any code to execute or the one with just pass statement

