### PR TITLE
Issue 232: Fix deprecation warning caused due to xunit1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
-addopts = -v -s -rsxX --continue-on-collection-errors --tb=short --ignore=utils/Test_Rail.py --ignore=tests/test_boilerplate.py --ignore=utils/Test_Runner_Class.py -p no:cacheprovider 
+addopts = -v -s -rsxX --continue-on-collection-errors --tb=short --ignore=utils/Test_Rail.py --ignore=tests/test_boilerplate.py --ignore=utils/Test_Runner_Class.py -p no:cacheprovider
 norecursedirs = .svn _build tmp* log .vscode .git
 markers =
     GUI: mark a test as part of the GUI regression suite
     API: mark a test as part of the API regression suite
  MOBILE: mark a test as part of the MOBILE regression suite
+junit_family=xunit2


### PR DESCRIPTION
This PR is created for the following issue:
https://github.com/qxf2/qxf2-page-object-model/issues/232

I have added `junit_family=xunit2` in the `pytest.ini` file. I have referred the following documentation to make the change.

`https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2`