### PR TITLE
fixed unused import statements highlighted by codacy

### DIFF
--- a/conf/test_path_conf.py
+++ b/conf/test_path_conf.py
@@ -1,7 +1,7 @@
 """
 This conf file would have the relative paths of the files & folders.
 """
-import os,sys
+import os
 
 #POM
 #Files from src POM:

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -7,10 +7,8 @@ c) maintains the test context/state
 from base64 import b64encode
 from .API_Interface import API_Interface
 from utils.results import Results
-import json
 import urllib.parse
 import logging
-from utils.__init__ import get_dict_item
 from conf import api_example_conf as conf
 
 

--- a/endpoints/Base_API.py
+++ b/endpoints/Base_API.py
@@ -2,12 +2,9 @@
 A wrapper around Requests to make Restful API calls
 """
 
-import json
 import requests
-from requests.auth import HTTPBasicAuth
 from urllib.error import HTTPError
 from urllib.error import URLError
-from conf import api_example_conf as conf
 
 class Base_API:
     "Main base class for Requests based scripts"

--- a/endpoints/Cars_API_Endpoints.py
+++ b/endpoints/Cars_API_Endpoints.py
@@ -3,7 +3,6 @@ API endpoints for Cars
 """
 
 from .Base_API import Base_API
-import json
 
 class Cars_API_Endpoints(Base_API):
 	"Class for cars endpoints"

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -2,17 +2,12 @@
 Page class that all page models can inherit from
 There are useful wrappers for common Selenium operations
 """
-
-from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
 import unittest,time,logging,os,inspect,utils.Test_Rail,pytest
 from utils.Base_Logging import Base_Logging
-from inspect import getargspec
 from utils.BrowserStack_Library import BrowserStack_Library
 from .DriverFactory import DriverFactory
 from page_objects import PageFactory

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -7,9 +7,7 @@ NOTE: Change this class as you add support for:
 import dotenv,os,sys,requests,json
 from datetime import datetime
 from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from selenium.webdriver.chrome import service
 from selenium.webdriver.remote.webdriver import RemoteConnection
 from appium import webdriver as mobile_webdriver
 from conf import remote_credentials

--- a/page_objects/Mobile_Base_Page.py
+++ b/page_objects/Mobile_Base_Page.py
@@ -7,7 +7,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
-import sys,unittest,time,logging,os,inspect
+import unittest,time,logging,os,inspect
 from utils.Base_Logging import Base_Logging
 from utils.BrowserStack_Library import BrowserStack_Library
 from .DriverFactory import DriverFactory

--- a/page_objects/Mobile_Base_Page.py
+++ b/page_objects/Mobile_Base_Page.py
@@ -2,8 +2,6 @@
 Page class that all page models can inherit from
 There are useful wrappers for common Selenium operations
 """
-from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
@@ -11,7 +9,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
 import sys,unittest,time,logging,os,inspect
 from utils.Base_Logging import Base_Logging
-from inspect import getargspec
 from utils.BrowserStack_Library import BrowserStack_Library
 from .DriverFactory import DriverFactory
 from utils.Test_Rail import Test_Rail

--- a/page_objects/contact_form_object.py
+++ b/page_objects/contact_form_object.py
@@ -2,8 +2,6 @@
 This class models the form on contact page
 The form consists of some input fields.
 """
-
-from .Base_Page import Base_Page
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit
 

--- a/page_objects/contact_page.py
+++ b/page_objects/contact_page.py
@@ -7,7 +7,6 @@ from .Base_Page import Base_Page
 from .contact_form_object import Contact_Form_Object
 from .header_object import Header_Object
 from .footer_object import Footer_Object
-from utils.Wrapit import Wrapit
 
 class Contact_Page(Base_Page,Contact_Form_Object,Header_Object,Footer_Object):
     "Page Object for the contact page"

--- a/page_objects/footer_object.py
+++ b/page_objects/footer_object.py
@@ -5,7 +5,6 @@ We model it as two parts:
 2. The copyright
 """
 from datetime import datetime
-from .Base_Page import Base_Page
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit
 

--- a/page_objects/form_object.py
+++ b/page_objects/form_object.py
@@ -2,8 +2,6 @@
 This class models the form on the Selenium tutorial page
 The form consists of some input fields, a dropdown, a checkbox and a button
 """
-
-from .Base_Page import Base_Page
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit
 

--- a/page_objects/hamburger_menu_object.py
+++ b/page_objects/hamburger_menu_object.py
@@ -4,7 +4,6 @@ The hamburger menu has a bunch of options that can be:
 a) Clicked
 b) Hovered over
 """
-from .Base_Page import Base_Page
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit
 

--- a/page_objects/header_object.py
+++ b/page_objects/header_object.py
@@ -3,7 +3,7 @@ This class models the Qxf2.com header as a Page Object.
 The header consists of the Qxf2 logo, Qxf2 tag-line and the hamburger menu
 Since the hanburger menu is complex, we will model it as a separate object
 """
-from .Base_Page import Base_Page
+
 from .hamburger_menu_object import Hamburger_Menu_Object
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit

--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -14,12 +14,10 @@ API EXAMPLE TEST
 
 import os
 import sys
-import os,sys,time,pytest
+import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from endpoints.API_Player import API_Player
 from conf import api_example_conf as conf
-import pytest
-
 
 @pytest.mark.API
 def test_api_example(api_url='http://35.167.62.251/'):

--- a/tests/test_example_form.py
+++ b/tests/test_example_form.py
@@ -5,7 +5,7 @@ Our automated test will do the following:
     #Fill the example form.
     #Click on Click me! button and check if its working fine.
 """
-import os,sys,time,pytest
+import os,sys,time
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from page_objects.PageFactory import PageFactory
 from utils.Option_Parser import Option_Parser

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -3,8 +3,6 @@ Qxf2 Services: A plug-n-play class for logging.
 This class wraps around Python's loguru module.
 """
 import os, inspect
-import datetime
-import sys
 import pytest,logging
 from loguru import logger
 from pytest_reportportal import RPLogger, RPLogHandler

--- a/utils/Option_Parser.py
+++ b/utils/Option_Parser.py
@@ -1,7 +1,6 @@
 """
 Class to wrap around parsing command line options
 """
-import os, sys
 import optparse
 from conf import base_url_conf as conf
 

--- a/utils/Test_Rail.py
+++ b/utils/Test_Rail.py
@@ -6,7 +6,7 @@ TestRail integration:
 
 API reference: http://docs.gurock.com/testrail-api2/start
 """
-import dotenv,os,sys
+import os,sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils import testrail
 import conf.testrailenv_conf as conf_file

--- a/utils/Wrapit.py
+++ b/utils/Wrapit.py
@@ -3,7 +3,6 @@ Class to hold miscellaneous but useful decorators for our framework
 """
 
 from inspect import getfullargspec
-from page_objects.Base_Page import Base_Page
 
 
 class Wrapit():


### PR DESCRIPTION
I have fixed all import statements except following, as either they were giving import error or I observed those being used in the file.

```
1. conf/test_path_conf.py
import os,sys

2. from page_objects/Base_Page.py 
import unittest,time,logging,os,inspect,utils.Test_Rail,pytest

3. from page_objects/tutorial_main_page.py 
from .Base_Page import Base_Page

4. from page_objects/contact_page.py
from .Base_Page import Base_Page

5. from utils/Test_Rail.py
import dotenv,os,sys

6. from utils/copy_framework_template.py
import os,sys

7. from page_objects/DriverFactory.py
import dotenv,os,sys,requests,json

8. from utils/Image_Compare.py
import math,operator,os

9. from utils/email_util.py
import os,sys,time,imaplib,email,datetime

10. utils/ssh_util.py
import os,sys,time

11. utils/BrowserStack_Library.py
import os,requests,sys

```