### PR TITLE
Issue 246 conftest cli options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,9 +70,9 @@ a) Get setup with your browser driver. If you don't know how to, please try:
 
 __If your setup goes well__, you should be to run a simple test with this command:
 
-1. Chrome: `python -m pytest -k example_form -B Chrome`
+1. Chrome: `python -m pytest -k example_form --browser Chrome`
 
-2. Firefox: `python -m pytest -k example_form -B Firefox`
+2. Firefox: `python -m pytest -k example_form --browser Firefox`
 
 __Optional steps__ for integrating with third-party tools:
 
@@ -97,7 +97,7 @@ d) [Install the appium Python client library](https://pypi.python.org/pypi/Appiu
 pip install Appium-Python-Client
 
 __If your setup goes well__, you should be to run a simple mobile test with this command after starting the Appium and Android emulator:
-`python -m pytest -k mobile_bitcoin_price -H $Emulator_OS_Version -I $Emulator_Name`
+`python -m pytest -k mobile_bitcoin_price --mobile_os_version $Emulator_OS_Version --device_name $Emulator_Name`
 
 __Optional steps__ for more details on setting up appium and running tests on Android or iOS refer to below links:
 * [Get started with mobile automation: Appium & Python](https://qxf2.com/blog/appium-mobile-automation/)
@@ -140,23 +140,23 @@ COMMANDS FOR RUNNING TESTS
 a)py.test [options]
 
 	-s	used to display the output on the screen			E.g: python -m pytest -s (This will run all the tests in the directory and subdirectories)
-	-U  	used to run against specific URL				E.g: python -m pytest -U http://YOUR_localhost_URL (This will run against your local instance)
-	-M  	used to run tests on Browserstack/Sauce Lab			E.g: python -m pytest -s -M Y -U https://qxf2.com
-	-B all	used to run the test against multiple browser 			E.g:python -m pytest -B all(This will run each test against the list of browsers specified in the conftest.py file,firefox and chrome in our case)
+	--base_url  used to run against specific URL			E.g: python -m pytest --base_url http://YOUR_localhost_URL (This will run against your local instance)
+	--remote_flag  used to run tests on Browserstack/Sauce Lab	E.g: python -m pytest -s --remote_flag Y -U https://qxf2.com
+	--browser all	used to run the test against multiple browser 			E.g:python -m pytest ---browser all(This will run each test against the list of browsers specified in the conftest.py file,firefox and chrome in our case)
 	--ver/-O	used to run against different browser versions/os versions	E.g: python -m pytest --ver 44 -O 8 (This will run each test 4 times in different browser version(default=45 & 44) and OS(default=7 & 8) combination)
 	-h	help for more options 						E.g: python -m pytest -h
 	-k      used to run tests which match the given substring expresion 	E.g: python -m pytest -k table  (This will trigger test_example_table.py test)
-	-S	used to post pytest reports on the Slack channel		E.g: python -m pytest -S Y -v > log/pytest_report.log
+	--slack_flag	used to post pytest reports on the Slack channel		E.g: python -m pytest --slack_flag Y -v > log/pytest_report.log
 	-n 	used to run tests in parallel					E.g: python -m pytest -n 3 -v (This will run three tests in parallel)
 	--tesults 	used to report test results to tesults			E.g: python -m pytest test_example_form.py --tesults Y(This will report test report to tesults)
 
 b)python tests/test_example_form.py (can also be used to run standalone test)
 
-c)python tests/test_example_form.py -B Chrome (to run against chrome)
+c)python tests/test_example_form.py --browser Chrome (to run against chrome)
 
 d)python tests/test_api_example.py (make sure to run sample cars-api available at qxf2/cars-api repository before api test run)
 
-e)python tests/test_mobile_bitcoin_price -H (android version) -I (simulator) -N (.apk location on local) -M Y (to run Mobile test case on Broswestack)remote_credentials.py
+e)python tests/test_mobile_bitcoin_price --mobile_os_version (android version) --device_name (simulator) --app_path (.apk location on local) --remote_flag Y (to run Mobile test case on Broswestack)remote_credentials.py
 NOTE: For running tests in Browserstack, need to update Username/Accesskey from Browserstack Account to remote_credentials.py under conf.
 
 --------

--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,7 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
             if test_run_id is not None:
                 test_mobile_obj.register_testrail()
                 test_mobile_obj.set_test_run_id(test_run_id)
-  
+
         if tesults_flag.lower()=='y':
             test_mobile_obj.register_tesults()
 
@@ -394,7 +394,7 @@ def pytest_configure(config):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-    "Registering custom markers to supress warnings"
+    #Registering custom markers to supress warnings
     config.addinivalue_line("markers", "GUI: mark a test as part of the GUI regression suite.")
     config.addinivalue_line("markers", "API: mark a test as part of the GUI regression suite.")
     config.addinivalue_line("markers", "MOBILE: mark a test as part of the GUI regression suite.")
@@ -403,7 +403,7 @@ def pytest_configure(config):
 def pytest_terminal_summary(terminalreporter, exitstatus):
     "add additional section in terminal summary reporting."
     try:
-        if  terminalreporter.config.getoption("-S").lower() == 'y':
+        if  terminalreporter.config.getoption("--slack_flag").lower() == 'y':
             post_test_reports_to_slack.post_reports_to_slack()
         if terminalreporter.config.getoption("--email_pytest_report").lower() == 'y':
             #Initialize the Email_Pytest_Report object
@@ -421,27 +421,27 @@ def pytest_terminal_summary(terminalreporter, exitstatus):
 def pytest_generate_tests(metafunc):
     "test generator function to run tests across different parameters"
     try:
-      if 'browser' in metafunc.fixturenames:
-          if metafunc.config.getoption("--remote_flag").lower() == 'y':
-              if metafunc.config.getoption("--browser") == ["all"]:
-                  metafunc.parametrize("browser,browser_version,os_name,os_version",
-                                      browser_os_name_conf.cross_browser_cross_platform_config)
-              elif metafunc.config.getoption("--browser") == ["Chrome"]:
-                  metafunc.parametrize("browser,browser_version,os_name,os_version",
-                                      browser_os_name_conf.default_config_list)
-              else:
-                  config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("--os_name")[0],metafunc.config.getoption("--os_version")[0])]
-                  metafunc.parametrize("browser,browser_version,os_name,os_version",
-                                      config_list)
-          if metafunc.config.getoption("--remote_flag").lower() !='y':
-              if metafunc.config.getoption("--browser") == ["all"]:
-                  metafunc.config.option.browser = browser_os_name_conf.local_browsers
-                  metafunc.parametrize("browser", metafunc.config.option.browser)
-              elif metafunc.config.getoption("--browser") == []:
-                  metafunc.parametrize("browser",browser_os_name_conf.default_browser)
-              else:
-                  config_list_local = [(metafunc.config.getoption("--browser")[0])]
-                  metafunc.parametrize("browser", config_list_local)
+        if 'browser' in metafunc.fixturenames:
+            if metafunc.config.getoption("--remote_flag").lower() == 'y':
+                if metafunc.config.getoption("--browser") == ["all"]:
+                    metafunc.parametrize("browser,browser_version,os_name,os_version",
+                                        browser_os_name_conf.cross_browser_cross_platform_config)
+                elif metafunc.config.getoption("--browser") == ["Chrome"]:
+                    metafunc.parametrize("browser,browser_version,os_name,os_version",
+                                        browser_os_name_conf.default_config_list)
+                else:
+                    config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("--os_name")[0],metafunc.config.getoption("--os_version")[0])]
+                    metafunc.parametrize("browser,browser_version,os_name,os_version",
+                                        config_list)
+            if metafunc.config.getoption("--remote_flag").lower() !='y':
+                if metafunc.config.getoption("--browser") == ["all"]:
+                    metafunc.config.option.browser = browser_os_name_conf.local_browsers
+                    metafunc.parametrize("browser", metafunc.config.option.browser)
+                elif metafunc.config.getoption("--browser") == []:
+                    metafunc.parametrize("browser",browser_os_name_conf.default_browser)
+                else:
+                    config_list_local = [(metafunc.config.getoption("--browser")[0])]
+                    metafunc.parametrize("browser", config_list_local)
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
@@ -453,128 +453,123 @@ def pytest_generate_tests(metafunc):
 def pytest_addoption(parser):
     "Method to add the option to ini."
     try:
-      parser.addini("rp_uuid",'help',type="pathlist")
-      parser.addini("rp_endpoint",'help',type="pathlist")
-      parser.addini("rp_project",'help',type="pathlist")
-      parser.addini("rp_launch",'help',type="pathlist")
+        parser.addini("rp_uuid",'help',type="pathlist")
+        parser.addini("rp_endpoint",'help',type="pathlist")
+        parser.addini("rp_project",'help',type="pathlist")
+        parser.addini("rp_launch",'help',type="pathlist")
 
-      parser.addoption("--browser",
-                        dest="browser",
-                        action="append",
-                        default=['Chrome'],
-                        help="Browser. Valid options are firefox, ie and chrome")
-      parser.addoption("--app_url",
-                        dest="url",
-                        default=base_url_conf.base_url,
-                        help="The url of the application")
-      parser.addoption("--api_url",
-                        dest="url",
-                        default="http://35.167.62.251",
-                        help="The url of the api")
-      parser.addoption("--testrail_flag",
-                        dest="testrail_flag",
-                        default='N',
-                        help="Y or N. 'Y' if you want to report to TestRail")
-      parser.addoption("--test_run_id",
-                        dest="test_run_id",
-                        default=None,
-                        help="The test run id in TestRail")
-      parser.addoption("--remote_flag",
-                        dest="remote_flag",
-                        default="N",
-                        help="Run the test in Browserstack/Sauce Lab: Y or N")
-      parser.addoption("--os_version",
-                        dest="os_version",
-                        action="append",
-                        help="The operating system: xp, 7",
-                        default=[])
-      parser.addoption("--ver",
-                        dest="browser_version",
-                        action="append",
-                        help="The version of the browser: a whole number",
-                        default=[])
-      parser.addoption("--os_name",
-                        dest="os_name",
-                        action="append",
-                        help="The operating system: Windows 7, Linux",
-                        default=[])
-      parser.addoption("--remote_project_name",
-                        dest="remote_project_name",
-                        help="The project name if its run in BrowserStack",
-                        default=None)
-      parser.addoption("--remote_build_name",
-                        dest="remote_build_name",
-                        help="The build name if its run in BrowserStack",
-                        default=None)
-      parser.addoption("--slack_flag",
-                        dest="slack_flag",
-                        default="N",
-                        help="Post the test report on slack channel: Y or N")
-      parser.addoption("--mobile_os_name",
-                        dest="mobile_os_name",
-                        help="Enter operating system of mobile. Ex: Android, iOS",
-                        default="Android")
-      parser.addoption("--mobile_os_version",
-                        dest="mobile_os_version",
-                        help="Enter version of operating system of mobile: 8.1.0",
-                        default="8.0")
-      parser.addoption("--device_name",
-                        dest="device_name",
-                        help="Enter device name. Ex: Emulator, physical device name",
-                        default="Samsung Galaxy S9")
-      parser.addoption("--app_package",
-                        dest="app_package",
-                        help="Enter name of app package. Ex: bitcoininfo",
-                        default="com.dudam.rohan.bitcoininfo")
-      parser.addoption("--app_activity",
-                        dest="app_activity",
-                        help="Enter name of app activity. Ex: .MainActivity",
-                        default=".MainActivity")
-      parser.addoption("--device_flag",
-                        dest="device_flag",
-                        help="Enter Y or N. 'Y' if you want to run the test on device. 'N' if you want to run the test on emulator.",
-                        default="N")
-      parser.addoption("--email_pytest_report",
-                        dest="email_pytest_report",
-                        help="Email pytest report: Y or N",
-                        default="N")
-      parser.addoption("--tesults",
-                        dest="tesults_flag",
-                        default='N',
-                        help="Y or N. 'Y' if you want to report results with Tesults")
-      parser.addoption("--app_name",
-                        dest="app_name",
-                        help="Enter application name to be uploaded.Ex:Bitcoin Info_com.dudam.rohan.bitcoininfo.apk.",
-                        default="Bitcoin Info_com.dudam.rohan.bitcoininfo.apk")
-      parser.addoption("--ud_id",
-                        dest="ud_id",
-                        help="Enter your iOS device UDID which is required to run appium test in iOS device",
-                        default=None)
-      parser.addoption("--org_id",
-                        dest="org_id",
-                        help="Enter your iOS Team ID which is required to run appium test in iOS device",
-                        default=None)
-      parser.addoption("--signing_id",
-                        dest="signing_id",
-                        help="Enter your iOS app signing id which is required to run appium test in iOS device",
-                        default="iPhone Developer")
-      parser.addoption("--no_reset_flag",
-                        dest="no_reset_flag",
-                        help="Pass false if you want to reset app eveytime you run app else false",
-                        default="true")
-      parser.addoption("--app_path",
-                        dest="app_path",
-                        help="Enter app path")
-      parser.addoption("--appium_version",
-                        dest="appium_version",
-                        help="The appium version if its run in BrowserStack",
-                        default="1.17.0")
+        parser.addoption("--browser",
+                            dest="browser",
+                            action="append",
+                            default=['Chrome'],
+                            help="Browser. Valid options are firefox, ie and chrome")
+        parser.addoption("--app_url",
+                            dest="url",
+                            default=base_url_conf.base_url,
+                            help="The url of the application")
+        parser.addoption("--api_url",
+                            dest="url",
+                            default="http://35.167.62.251",
+                            help="The url of the api")
+        parser.addoption("--testrail_flag",
+                            dest="testrail_flag",
+                            default='N',
+                            help="Y or N. 'Y' if you want to report to TestRail")
+        parser.addoption("--test_run_id",
+                            dest="test_run_id",
+                            default=None,
+                            help="The test run id in TestRail")
+        parser.addoption("--remote_flag",
+                            dest="remote_flag",
+                            default="N",
+                            help="Run the test in Browserstack/Sauce Lab: Y or N")
+        parser.addoption("--os_version",
+                            dest="os_version",
+                            action="append",
+                            help="The operating system: xp, 7",
+                            default=[])
+        parser.addoption("--ver",
+                            dest="browser_version",
+                            action="append",
+                            help="The version of the browser: a whole number",
+                            default=[])
+        parser.addoption("--os_name",
+                            dest="os_name",
+                            action="append",
+                            help="The operating system: Windows 7, Linux",
+                            default=[])
+        parser.addoption("--remote_project_name",
+                            dest="remote_project_name",
+                            help="The project name if its run in BrowserStack",
+                            default=None)
+        parser.addoption("--remote_build_name",
+                            dest="remote_build_name",
+                            help="The build name if its run in BrowserStack",
+                            default=None)
+        parser.addoption("--slack_flag",
+                            dest="slack_flag",
+                            default="N",
+                            help="Post the test report on slack channel: Y or N")
+        parser.addoption("--mobile_os_name",
+                            dest="mobile_os_name",
+                            help="Enter operating system of mobile. Ex: Android, iOS",
+                            default="Android")
+        parser.addoption("--mobile_os_version",
+                            dest="mobile_os_version",
+                            help="Enter version of operating system of mobile: 8.1.0",
+                            default="8.0")
+        parser.addoption("--device_name",
+                            dest="device_name",
+                            help="Enter device name. Ex: Emulator, physical device name",
+                            default="Samsung Galaxy S9")
+        parser.addoption("--app_package",
+                            dest="app_package",
+                            help="Enter name of app package. Ex: bitcoininfo",
+                            default="com.dudam.rohan.bitcoininfo")
+        parser.addoption("--app_activity",
+                            dest="app_activity",
+                            help="Enter name of app activity. Ex: .MainActivity",
+                            default=".MainActivity")
+        parser.addoption("--device_flag",
+                            dest="device_flag",
+                            help="Enter Y or N. 'Y' if you want to run the test on device. 'N' if you want to run the test on emulator.",
+                            default="N")
+        parser.addoption("--email_pytest_report",
+                            dest="email_pytest_report",
+                            help="Email pytest report: Y or N",
+                            default="N")
+        parser.addoption("--tesults",
+                            dest="tesults_flag",
+                            default='N',
+                            help="Y or N. 'Y' if you want to report results with Tesults")
+        parser.addoption("--app_name",
+                            dest="app_name",
+                            help="Enter application name to be uploaded.Ex:Bitcoin Info_com.dudam.rohan.bitcoininfo.apk.",
+                            default="Bitcoin Info_com.dudam.rohan.bitcoininfo.apk")
+        parser.addoption("--ud_id",
+                            dest="ud_id",
+                            help="Enter your iOS device UDID which is required to run appium test in iOS device",
+                            default=None)
+        parser.addoption("--org_id",
+                            dest="org_id",
+                            help="Enter your iOS Team ID which is required to run appium test in iOS device",
+                            default=None)
+        parser.addoption("--signing_id",
+                            dest="signing_id",
+                            help="Enter your iOS app signing id which is required to run appium test in iOS device",
+                            default="iPhone Developer")
+        parser.addoption("--no_reset_flag",
+                            dest="no_reset_flag",
+                            help="Pass false if you want to reset app eveytime you run app else false",
+                            default="true")
+        parser.addoption("--app_path",
+                            dest="app_path",
+                            help="Enter app path")
+        parser.addoption("--appium_version",
+                            dest="appium_version",
+                            help="The appium version if its run in BrowserStack",
+                            default="1.17.0")
 
-      except Exception as e:
-          print("Exception when trying to run test: %s"%__file__)
-          print("Python says:%s"%str(e))
-
-
-
-
-
+    except Exception as e:
+        print("Exception when trying to run test: %s"%__file__)
+        print("Python says:%s"%str(e))

--- a/conftest.py
+++ b/conftest.py
@@ -246,6 +246,11 @@ def pytest_configure(config):
     except Exception as e:
         print (str(e))
 
+    "Registering custom markers to supress warnings"
+    config.addinivalue_line("markers", "GUI: mark a test as part of the GUI regression suite.")
+    config.addinivalue_line("markers", "API: mark a test as part of the GUI regression suite.")
+    config.addinivalue_line("markers", "MOBILE: mark a test as part of the GUI regression suite.")
+
 
 def pytest_terminal_summary(terminalreporter, exitstatus):
     "add additional section in terminal summary reporting."

--- a/conftest.py
+++ b/conftest.py
@@ -193,7 +193,7 @@ def email_pytest_report(request):
 @pytest.fixture
 def app_name(request):
     "pytest fixture for app name"
-    return request.config.getoption("-D")
+    return request.config.getoption("--app_name")
 
 
 @pytest.fixture
@@ -272,7 +272,7 @@ def pytest_generate_tests(metafunc):
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.default_config_list)
             else:
-                config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
+                config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("--os_name")[0],metafunc.config.getoption("--os_version")[0])]
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     config_list)
         if metafunc.config.getoption("--remote_flag").lower() !='y':
@@ -378,7 +378,7 @@ def pytest_addoption(parser):
                       dest="tesults_flag",
                       default='N',
                       help="Y or N. 'Y' if you want to report results with Tesults")
-    parser.addoption("-D","--app_name",
+    parser.addoption("--app_name",
                       dest="app_name",
                       help="Enter application name to be uploaded.Ex:Bitcoin Info_com.dudam.rohan.bitcoininfo.apk.",
                       default="Bitcoin Info_com.dudam.rohan.bitcoininfo.apk")

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,tes
     #Setup TestRail reporting
     if testrail_flag.lower()=='y':
         if test_run_id is None:
-            test_obj.write('\033[91m'+"\n\nTestRail Integration Exception: It looks like you are trying to use TestRail Integration without providing test run id. \nPlease provide a valid test run id along with test run command using -R flag and try again. for eg: pytest -X Y -R 100\n"+'\033[0m')
+            test_obj.write('\033[91m'+"\n\nTestRail Integration Exception: It looks like you are trying to use TestRail Integration without providing test run id. \nPlease provide a valid test run id along with test run command using -R flag and try again. for eg: pytest --testrail_flag Y -R 100\n"+'\033[0m')
             testrail_flag = 'N'
         if test_run_id is not None:
             test_obj.register_testrail()
@@ -45,7 +45,7 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
     #3. Setup TestRail reporting
     if testrail_flag.lower()=='y':
         if test_run_id is None:
-            test_mobile_obj.write('\033[91m'+"\n\nTestRail Integration Exception: It looks like you are trying to use TestRail Integration without providing test run id. \nPlease provide a valid test run id along with test run command using -R flag and try again. for eg: pytest -X Y -R 100\n"+'\033[0m')
+            test_mobile_obj.write('\033[91m'+"\n\nTestRail Integration Exception: It looks like you are trying to use TestRail Integration without providing test run id. \nPlease provide a valid test run id along with test run command using -R flag and try again. for eg: pytest --testrail_flag Y -R 100\n"+'\033[0m')
             testrail_flag = 'N'
         if test_run_id is not None:
             test_mobile_obj.register_testrail()
@@ -91,13 +91,13 @@ def api_url(request):
 @pytest.fixture
 def test_run_id(request):
     "pytest fixture for test run id"
-    return request.config.getoption("-R")
+    return request.config.getoption("--test_run_id")
 
 
 @pytest.fixture
 def testrail_flag(request):
     "pytest fixture for test rail flag"
-    return request.config.getoption("-X")
+    return request.config.getoption("--testrail_flag")
 
 
 @pytest.fixture
@@ -115,13 +115,13 @@ def browser_version(request):
 @pytest.fixture
 def os_name(request):
     "pytest fixture for os_name"
-    return request.config.getoption("-P")
+    return request.config.getoption("--os_name")
 
 
 @pytest.fixture
 def os_version(request):
     "pytest fixture for os version"
-    return request.config.getoption("-O")
+    return request.config.getoption("--os_version")
 
 
 @pytest.fixture
@@ -307,11 +307,11 @@ def pytest_addoption(parser):
                       dest="url",
                       default="http://35.167.62.251",
                       help="The url of the api")
-    parser.addoption("-X","--testrail_flag",
+    parser.addoption("--testrail_flag",
                       dest="testrail_flag",
                       default='N',
                       help="Y or N. 'Y' if you want to report to TestRail")
-    parser.addoption("-R","--test_run_id",
+    parser.addoption("--test_run_id",
                       dest="test_run_id",
                       default=None,
                       help="The test run id in TestRail")
@@ -319,7 +319,7 @@ def pytest_addoption(parser):
                       dest="remote_flag",
                       default="N",
                       help="Run the test in Browserstack/Sauce Lab: Y or N")
-    parser.addoption("-O","--os_version",
+    parser.addoption("--os_version",
                       dest="os_version",
                       action="append",
                       help="The operating system: xp, 7",
@@ -329,7 +329,7 @@ def pytest_addoption(parser):
                       action="append",
                       help="The version of the browser: a whole number",
                       default=[])
-    parser.addoption("-P","--os_name",
+    parser.addoption("--os_name",
                       dest="os_name",
                       action="append",
                       help="The operating system: Windows 7, Linux",

--- a/conftest.py
+++ b/conftest.py
@@ -103,7 +103,7 @@ def testrail_flag(request):
 @pytest.fixture
 def remote_flag(request):
     "pytest fixture for browserstack/sauce flag"
-    return request.config.getoption("-M")
+    return request.config.getoption("--remote_flag")
 
 
 @pytest.fixture
@@ -151,19 +151,19 @@ def tesults_flag(request):
 @pytest.fixture
 def mobile_os_name(request):
     "pytest fixture for mobile os name"
-    return request.config.getoption("-G")
+    return request.config.getoption("--mobile_os_name")
 
 
 @pytest.fixture
 def mobile_os_version(request):
     "pytest fixture for mobile os version"
-    return request.config.getoption("-H")
+    return request.config.getoption("--mobile_os_version")
 
 
 @pytest.fixture
 def device_name(request):
     "pytest fixture for device name"
-    return request.config.getoption("-I")
+    return request.config.getoption("--device_name")
 
 
 @pytest.fixture
@@ -181,7 +181,7 @@ def app_activity(request):
 @pytest.fixture
 def device_flag(request):
     "pytest fixture for device flag"
-    return request.config.getoption("-Q")
+    return request.config.getoption("--device_flag")
 
 
 @pytest.fixture
@@ -228,7 +228,7 @@ def no_reset_flag(request):
 @pytest.fixture
 def app_path(request):
     "pytest fixture for app path"
-    return request.config.getoption("-N")
+    return request.config.getoption("--app_path")
 
 
 @pytest.hookimpl()
@@ -264,7 +264,7 @@ def pytest_generate_tests(metafunc):
     "test generator function to run tests across different parameters"
 
     if 'browser' in metafunc.fixturenames:
-        if metafunc.config.getoption("-M").lower() == 'y':
+        if metafunc.config.getoption("--remote_flag").lower() == 'y':
             if metafunc.config.getoption("--browser") == ["all"]:
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.cross_browser_cross_platform_config)
@@ -275,7 +275,7 @@ def pytest_generate_tests(metafunc):
                 config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     config_list)
-        if metafunc.config.getoption("-M").lower() !='y':
+        if metafunc.config.getoption("--remote_flag").lower() !='y':
             if metafunc.config.getoption("--browser") == ["all"]:
                 metafunc.config.option.browser = browser_os_name_conf.local_browsers
                 metafunc.parametrize("browser", metafunc.config.option.browser)
@@ -315,7 +315,7 @@ def pytest_addoption(parser):
                       dest="test_run_id",
                       default=None,
                       help="The test run id in TestRail")
-    parser.addoption("-M","--remote_flag",
+    parser.addoption("--remote_flag",
                       dest="remote_flag",
                       default="N",
                       help="Run the test in Browserstack/Sauce Lab: Y or N")
@@ -346,15 +346,15 @@ def pytest_addoption(parser):
                       dest="slack_flag",
                       default="N",
                       help="Post the test report on slack channel: Y or N")
-    parser.addoption("-G","--mobile_os_name",
+    parser.addoption("--mobile_os_name",
                       dest="mobile_os_name",
                       help="Enter operating system of mobile. Ex: Android, iOS",
                       default="Android")
-    parser.addoption("-H","--mobile_os_version",
+    parser.addoption("--mobile_os_version",
                       dest="mobile_os_version",
                       help="Enter version of operating system of mobile: 8.1.0",
                       default="8.0")
-    parser.addoption("-I","--device_name",
+    parser.addoption("--device_name",
                       dest="device_name",
                       help="Enter device name. Ex: Emulator, physical device name",
                       default="Samsung Galaxy S9")
@@ -366,7 +366,7 @@ def pytest_addoption(parser):
                       dest="app_activity",
                       help="Enter name of app activity. Ex: .MainActivity",
                       default=".MainActivity")
-    parser.addoption("-Q","--device_flag",
+    parser.addoption("--device_flag",
                       dest="device_flag",
                       help="Enter Y or N. 'Y' if you want to run the test on device. 'N' if you want to run the test on emulator.",
                       default="N")
@@ -398,7 +398,7 @@ def pytest_addoption(parser):
                       dest="no_reset_flag",
                       help="Pass false if you want to reset app eveytime you run app else false",
                       default="true")
-    parser.addoption("-N","--app_path",
+    parser.addoption("--app_path",
                       dest="app_path",
                       help="Enter app path")
     parser.addoption("--appium_version",

--- a/conftest.py
+++ b/conftest.py
@@ -73,19 +73,19 @@ def testname(request):
 @pytest.fixture
 def browser(request):
     "pytest fixture for browser"
-    return request.config.getoption("-B")
+    return request.config.getoption("--browser")
 
 
 @pytest.fixture
 def base_url(request):
     "pytest fixture for base url"
-    return request.config.getoption("-U")
+    return request.config.getoption("--app_url")
 
 
 @pytest.fixture
 def api_url(request):
     "pytest fixture for base url"
-    return request.config.getoption("-A")
+    return request.config.getoption("--api_url")
 
 
 @pytest.fixture
@@ -265,24 +265,24 @@ def pytest_generate_tests(metafunc):
 
     if 'browser' in metafunc.fixturenames:
         if metafunc.config.getoption("-M").lower() == 'y':
-            if metafunc.config.getoption("-B") == ["all"]:
+            if metafunc.config.getoption("--browser") == ["all"]:
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.cross_browser_cross_platform_config)
-            elif metafunc.config.getoption("-B") == []:
+            elif metafunc.config.getoption("--browser") == []:
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.default_config_list)
             else:
-                config_list = [(metafunc.config.getoption("-B")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
+                config_list = [(metafunc.config.getoption("--browser")[0],metafunc.config.getoption("--ver")[0],metafunc.config.getoption("-P")[0],metafunc.config.getoption("-O")[0])]
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     config_list)
         if metafunc.config.getoption("-M").lower() !='y':
-            if metafunc.config.getoption("-B") == ["all"]:
+            if metafunc.config.getoption("--browser") == ["all"]:
                 metafunc.config.option.browser = browser_os_name_conf.local_browsers
                 metafunc.parametrize("browser", metafunc.config.option.browser)
-            elif metafunc.config.getoption("-B") == []:
+            elif metafunc.config.getoption("--browser") == []:
                 metafunc.parametrize("browser",browser_os_name_conf.default_browser)
             else:
-                config_list_local = [(metafunc.config.getoption("-B")[0])]
+                config_list_local = [(metafunc.config.getoption("--browser")[0])]
                 metafunc.parametrize("browser", config_list_local)
 
 
@@ -294,16 +294,16 @@ def pytest_addoption(parser):
     parser.addini("rp_project",'help',type="pathlist")
     parser.addini("rp_launch",'help',type="pathlist")
 
-    parser.addoption("-B","--browser",
+    parser.addoption("--browser",
                       dest="browser",
                       action="append",
                       default=[],
                       help="Browser. Valid options are firefox, ie and chrome")
-    parser.addoption("-U","--app_url",
+    parser.addoption("--app_url",
                       dest="url",
                       default=base_url_conf.base_url,
                       help="The url of the application")
-    parser.addoption("-A","--api_url",
+    parser.addoption("--api_url",
                       dest="url",
                       default="http://35.167.62.251",
                       help="The url of the api")

--- a/conftest.py
+++ b/conftest.py
@@ -268,7 +268,7 @@ def pytest_generate_tests(metafunc):
             if metafunc.config.getoption("--browser") == ["all"]:
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.cross_browser_cross_platform_config)
-            elif metafunc.config.getoption("--browser") == []:
+            elif metafunc.config.getoption("--browser") == ["Chrome"]:
                 metafunc.parametrize("browser,browser_version,os_name,os_version",
                                     browser_os_name_conf.default_config_list)
             else:
@@ -297,7 +297,7 @@ def pytest_addoption(parser):
     parser.addoption("--browser",
                       dest="browser",
                       action="append",
-                      default=[],
+                      default=['Chrome'],
                       help="Browser. Valid options are firefox, ie and chrome")
     parser.addoption("--app_url",
                       dest="url",

--- a/conftest.py
+++ b/conftest.py
@@ -139,7 +139,7 @@ def remote_build_name(request):
 @pytest.fixture
 def slack_flag(request):
     "pytest fixture for sending reports on slack"
-    return request.config.getoption("-S")
+    return request.config.getoption("--slack_flag")
 
 
 @pytest.fixture
@@ -249,7 +249,7 @@ def pytest_configure(config):
 
 def pytest_terminal_summary(terminalreporter, exitstatus):
     "add additional section in terminal summary reporting."
-    if  terminalreporter.config.getoption("-S").lower() == 'y':
+    if  terminalreporter.config.getoption("--slack_flag").lower() == 'y':
         post_test_reports_to_slack.post_reports_to_slack()
     if terminalreporter.config.getoption("--email_pytest_report").lower() == 'y':
         #Initialize the Email_Pytest_Report object
@@ -342,7 +342,7 @@ def pytest_addoption(parser):
                       dest="remote_build_name",
                       help="The build name if its run in BrowserStack",
                       default=None)
-    parser.addoption("-S","--slack_flag",
+    parser.addoption("--slack_flag",
                       dest="slack_flag",
                       default="N",
                       help="Post the test report on slack channel: Y or N")

--- a/conftest.py
+++ b/conftest.py
@@ -169,13 +169,13 @@ def device_name(request):
 @pytest.fixture
 def app_package(request):
     "pytest fixture for app package"
-    return request.config.getoption("-J")
+    return request.config.getoption("--app_package")
 
 
 @pytest.fixture
 def app_activity(request):
     "pytest fixture for app activity"
-    return request.config.getoption("-K")
+    return request.config.getoption("--app_activity")
 
 
 @pytest.fixture
@@ -358,11 +358,11 @@ def pytest_addoption(parser):
                       dest="device_name",
                       help="Enter device name. Ex: Emulator, physical device name",
                       default="Samsung Galaxy S9")
-    parser.addoption("-J","--app_package",
+    parser.addoption("--app_package",
                       dest="app_package",
                       help="Enter name of app package. Ex: bitcoininfo",
                       default="com.dudam.rohan.bitcoininfo")
-    parser.addoption("-K","--app_activity",
+    parser.addoption("--app_activity",
                       dest="app_activity",
                       help="Enter name of app activity. Ex: .MainActivity",
                       default=".MainActivity")

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/bitcoin-info/app/
 
 #Command to run the test
-commands = python -m pytest -s -v -N {env:app_path} -M Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native
 

--- a/utils/Test_Rail.py
+++ b/utils/Test_Rail.py
@@ -13,6 +13,8 @@ import conf.testrailenv_conf as conf_file
 
 class Test_Rail:
     "Wrapper around TestRail's API"
+    # Added below to fix PytestCollectionWarning
+    __test__ = False
 
     def __init__(self):
         "Initialize the TestRail objects"


### PR DESCRIPTION
This PR is created for fixing issue #246 
In the `conftest.py` all the cli options changed to give support to only descriptive option.

I have tested this for web, API and mobile tests.