### PR TITLE
Cleaned up some simple Codacy warnings

### DIFF
--- a/conf/copy_framework_template_conf.py
+++ b/conf/copy_framework_template_conf.py
@@ -1,7 +1,7 @@
 """
 This conf file would have the relative paths of the files & folders.
 """
-import os,sys
+import os
 
 #dst_folder will be Myntra
 #Files from src:

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -195,8 +195,6 @@ class API_Player(Results):
             if response is not None:
                 user_list = result['user_list']
                 error = result['response']
-            if error is not None:
-                response_code = error
         except (TypeError, AttributeError) as e:
             raise e
 

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
-import unittest,time,logging,os,inspect,utils.Test_Rail,pytest
+import unittest,time,logging,os,inspect,pytest
 from utils.Base_Logging import Base_Logging
 from utils.BrowserStack_Library import BrowserStack_Library
 from .DriverFactory import DriverFactory
@@ -312,9 +312,9 @@ class Base_Page(Borg,unittest.TestCase):
     def get_window_by_name(self,window_name):
         "Return window handle id based on name"
         window_handle_id = None
-        for id,name in self.window_structure.iteritems():
+        for window_id,name in self.window_structure.iteritems():
             if name == window_name:
-                window_handle_id = id
+                window_handle_id = window_id
                 break
 
         return window_handle_id
@@ -721,7 +721,7 @@ class Base_Page(Borg,unittest.TestCase):
             path = self.split_locator(locator)
             WebDriverWait(self.driver, wait_seconds).until(EC.presence_of_element_located(path))
             result_flag =True
-        except Exception as e:
+        except Exception:
 	        self.conditional_write(result_flag,
                     positive='Located the element: %s'%locator,
                     negative='Could not locate the element %s even after %.1f seconds'%(locator,wait_seconds))

--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -4,7 +4,7 @@ NOTE: Change this class as you add support for:
 1. SauceLabs/BrowserStack
 2. More browsers like Opera
 """
-import dotenv,os,sys,requests,json
+import os,sys,requests,json
 from datetime import datetime
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
@@ -131,7 +131,7 @@ class DriverFactory():
         desired_capabilities['platformName'] = mobile_os_name
         desired_capabilities['platformVersion'] = mobile_os_version
         desired_capabilities['deviceName'] = device_name
-        
+
 
         if mobile_os_name in 'Android':
             if (remote_flag.lower() == 'y'):

--- a/page_objects/Mobile_Base_Page.py
+++ b/page_objects/Mobile_Base_Page.py
@@ -2,11 +2,8 @@
 Page class that all page models can inherit from
 There are useful wrappers for common Selenium operations
 """
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.action_chains import ActionChains
 import unittest,time,logging,os,inspect
 from utils.Base_Logging import Base_Logging
 from utils.BrowserStack_Library import BrowserStack_Library
@@ -417,7 +414,7 @@ class Mobile_Base_Page(Borg,unittest.TestCase):
             path = self.split_locator(locator)
             WebDriverWait(self.driver, wait_seconds).until(EC.presence_of_element_located(path))
             result_flag =True
-        except Exception as e:
+        except Exception:
                     self.conditional_write(result_flag,
                     positive='Located the element: %s'%locator,
                     negative='Could not locate the element %s even after %.1f seconds'%(locator,wait_time))

--- a/page_objects/footer_object.py
+++ b/page_objects/footer_object.py
@@ -37,12 +37,12 @@ class Footer_Object:
     @Wrapit._exceptionHandler
     def get_copyright(self):
         "Get the current copyright"
-        copyright = str(self.get_text(self.copyright_text))
-        copyright = copyright.strip()
+        copyright_slug = str(self.get_text(self.copyright_text))
+        copyright_slug = copyright_slug.strip()
         #NOTE: We strip out the special '&copy;
-        copyright = 'Qxf2' + copyright[:-1].split('Qxf2')[-1]
+        copyright_slug = 'Qxf2' + copyright_slug[:-1].split('Qxf2')[-1]
 
-        return copyright
+        return copyright_slug
 
 
     def get_current_year(self):

--- a/page_objects/table_object.py
+++ b/page_objects/table_object.py
@@ -1,7 +1,6 @@
 """
 This class models the table on the Selenium tutorial page
 """
-from .Base_Page import Base_Page
 import conf.locators_conf as locators
 from utils.Wrapit import Wrapit
 
@@ -29,7 +28,7 @@ class Table_Object:
         "Get the text within the table"
         table_text = []
         row_doms = self.get_elements(self.rows_xpath)
-        for index,row_dom in enumerate(row_doms):
+        for index in range(0,len(row_doms)):
             row_text = []
             cell_doms = self.get_elements(self.cols_relative_xpath%(index+1))
             for cell_dom in cell_doms:

--- a/page_objects/tutorial_main_page.py
+++ b/page_objects/tutorial_main_page.py
@@ -8,7 +8,6 @@ from .form_object import Form_Object
 from .header_object import Header_Object
 from .table_object import Table_Object
 from .footer_object import Footer_Object
-from utils.Wrapit import Wrapit
 
 
 class Tutorial_Main_Page(Base_Page,Form_Object,Header_Object,Table_Object,Footer_Object):

--- a/tests/test_boilerplate.py
+++ b/tests/test_boilerplate.py
@@ -1,7 +1,7 @@
 """
 This test file will help you get started in writing a new test using our framework
 """
-import os,sys,time
+import os,sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from page_objects.PageFactory import PageFactory
 from utils.Option_Parser import Option_Parser

--- a/utils/BrowserStack_Library.py
+++ b/utils/BrowserStack_Library.py
@@ -9,7 +9,7 @@ To do:
 a) Handle expired sessions better
 """
 
-import os,requests,sys
+import os,requests
 from conf import remote_credentials as remote_credentials
 
 

--- a/utils/Image_Compare.py
+++ b/utils/Image_Compare.py
@@ -4,7 +4,7 @@ Qxf2 Services: Utility script to compare images
 * Get the sum of colors in an image
 """
 from PIL import Image, ImageChops
-import math,operator,os
+import math, os
 
 def rmsdiff(im1,im2):
     "Calculate the root-mean-square difference between two images"

--- a/utils/Wrapit.py
+++ b/utils/Wrapit.py
@@ -10,7 +10,6 @@ class Wrapit():
     "Wrapit class to hold decorator functions"
     def _exceptionHandler(f):
         "Decorator to handle exceptions"
-        argspec = getfullargspec(f)
         def inner(*args,**kwargs):
             try:
                 return f(*args,**kwargs)

--- a/utils/email_util.py
+++ b/utils/email_util.py
@@ -13,7 +13,7 @@ A simple IMAP util that will help us with account activation
 3. Enhance get_latest_email_uid to make all parameters optional
 """
 #The import statements import: standard Python modules,conf
-import os,sys,time,imaplib,email,datetime
+import os,sys,time,imaplib,email
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import conf.email_conf as conf_file
 

--- a/utils/ssh_util.py
+++ b/utils/ssh_util.py
@@ -7,7 +7,7 @@ Qxf2 Services: Utility script to ssh into a remote server
 """
 
 import paramiko
-import os,sys,time
+import os,sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from conf import ssh_conf as conf_file
 import socket


### PR DESCRIPTION
Fixed warning about redefining built in id

Fixed unused imports and unused variable

Removed using enumerate when not needed

Removed an unused import

Removed an unused import

Removed an unused import

removed unusued import

Removed unusued variable

Removed an unused import

Removed unused import and an unused exception variable

Got rid of an uusued import

Removed an unused import

Renamed copyright variable to avoid using a built in name

Removed unusued import

Removed unused import