### PR TITLE
reverted default to [] in pytest_generat_tests and pytest_adoption me…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -426,7 +426,7 @@ def pytest_generate_tests(metafunc):
                 if metafunc.config.getoption("--browser") == ["all"]:
                     metafunc.parametrize("browser,browser_version,os_name,os_version",
                                         browser_os_name_conf.cross_browser_cross_platform_config)
-                elif metafunc.config.getoption("--browser") == ["Chrome"]:
+                elif metafunc.config.getoption("--browser") == []:
                     metafunc.parametrize("browser,browser_version,os_name,os_version",
                                         browser_os_name_conf.default_config_list)
                 else:
@@ -461,7 +461,7 @@ def pytest_addoption(parser):
         parser.addoption("--browser",
                             dest="browser",
                             action="append",
-                            default=['Chrome'],
+                            default=[],
                             help="Browser. Valid options are firefox, ie and chrome")
         parser.addoption("--app_url",
                             dest="url",


### PR DESCRIPTION
This is pull request for fixing issue_262:
`Revert parser.addoption browser from default ['Chrome'] to default[] as this blocking tests for other browsers to run`

I have changed the default browser settings default=[] from earlier default=['Chrome'] in the pytest_addoptiona and pytest_generate_tests methods.

can be tested using following now:
1.python -m pytest tests/test_example_form.py --browser firefox
2.python -m pytest -s -v -k mobile_bitcoin_price --mobile_os_version 8.0 --device_name "Samsung Galaxy S9" --app_path "C:\Users\apps" --app_name "Bitcoin Info_com.dudam.rohan.bitcoininfo.apk" --remote_flag Y