### PR TITLE
Issue 267_ Added support for running headless chrome test locally

### DIFF
--- a/page_objects/DriverFactory.py
+++ b/page_objects/DriverFactory.py
@@ -8,6 +8,7 @@ import os,sys,requests,json
 from datetime import datetime
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.remote.webdriver import RemoteConnection
 from appium import webdriver as mobile_webdriver
 from conf import remote_credentials
@@ -91,8 +92,7 @@ class DriverFactory():
         desired_capabilities['platform'] = os_name + ' '+os_version
 
 
-        return webdriver.Remote(command_executor="http://%s:%s@ondemand.saucelabs.com:80/wd/hub"%(USERNAME,PASSWORD),
-                desired_capabilities= desired_capabilities)
+        return webdriver.Remote(command_executor="http://%s:%s@ondemand.saucelabs.com:80/wd/hub"%(USERNAME,PASSWORD),desired_capabilities= desired_capabilities)
 
 
     def run_local(self,os_name,os_version,browser,browser_version):
@@ -118,6 +118,26 @@ class DriverFactory():
                      print("SOLUTION: It looks like you are trying to use Opera Browser. Please update Opera Browser location under conf/opera_browser_conf.\n")
         elif browser.lower() == "safari":
             local_driver = webdriver.Safari()
+        elif browser.lower() == "headless-chrome":
+            local_driver = self.get_headless_chrome_options()
+
+        return local_driver
+
+    def get_headless_chrome_options(self):
+        "Setting up healess chrom driver options"
+        options = Options()
+        options.headless = True
+        options.add_argument("--window-size=1920,1080")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--proxy-server='direct://'")
+        options.add_argument("--proxy-bypass-list=*")
+        options.add_argument("--start-maximized")
+        options.add_argument('--headless')
+        options.add_argument('--disable-gpu')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--ignore-certificate-errors')
+        local_driver = webdriver.Chrome(options=options)
 
         return local_driver
 
@@ -294,4 +314,3 @@ class DriverFactory():
         set_pref('pdfjs.disabled',True)
 
         return profile
-


### PR DESCRIPTION
[ ] what did you do?

Added support for the headless-chrome for running locally.

[ ] what change should the code reviewer expect visually?

Code reviewer should be able to run the test for headless chrome using the following command:
`python -m pytest tests/test_example_form.py --browser headless-chrome`

Note that after running the above test chrome browser should not get launched.

[ ] what files did you change?

In Driverfactory.py file following modifications done.
1. Added def get_headless_chrome_options().
2. In the def run_local() method added support for `headless-chrome`

[ ] how did you test the change?
I test it using following tests:
`python -m pytest --browser headless-chrome`

To check for regression, I ran following:
`python -m pytest -k example_form --browser chrome --ver 65 --os_name windows --os_version 10 --remote_flag Y`

`python -m pytest -s -v -k mobile_bitcoin_price --mobile_os_version 8.0 --device_name "Samsung Galaxy S9" --app_path "C:\Users\apps" --app_name "Bitcoin Info_com.dudam.rohan.bitcoininfo.apk" --remote_flag Y`

[ ] what explicit tradeoff did you make?
We have provided support to headless browser.

[ ] add links to references you used
This task was taken as R&D task and then decided to take up this in framework.
https://trello.com/c/I2FURQiS/8-run-a-python-selenium-test-in-chrome-headless-mode


[ ] how to run the change
`python -m pytest tests/test_example_form.py --browser headless-chrome`

Below are pylint and radon reports, which does not highlight any issue in the changed code.

```
page_objects\DriverFactory.py:145:4: R0914: Too many local variables (20/15) (too-many-locals)
page_objects\DriverFactory.py:148:8: C0103: Variable name "USERNAME" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:149:8: C0103: Variable name "PASSWORD" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:177:23: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:177:16: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:190:23: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:190:16: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:215:23: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:215:16: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:230:23: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:230:16: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:145:4: R0912: Too many branches (19/12) (too-many-branches)
page_objects\DriverFactory.py:145:4: R0915: Too many statements (77/50) (too-many-statements)
page_objects\DriverFactory.py:242:8: C0103: Variable name "USERNAME" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:243:8: C0103: Variable name "PASSWORD" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:259:15: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:248:12: C0103: Variable name "fp" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:259:8: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:240:4: R0201: Method could be a function (no-self-use)
page_objects\DriverFactory.py:266:8: C0103: Variable name "USERNAME" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:267:8: C0103: Variable name "ACESS_KEY" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:276:15: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:276:8: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:264:4: R0201: Method could be a function (no-self-use)
page_objects\DriverFactory.py:301:15: W0703: Catching too general exception Exception (broad-except)
page_objects\DriverFactory.py:301:8: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
page_objects\DriverFactory.py:298:12: W0201: Attribute 'download_dir' defined outside __init__ (attribute-defined-outside-init)
(venv3)
Rahul Bhave Qxf2@LAPTOP-S0A7MKF0 MINGW64 ~/code/rahul-qxf2/issue_215/qxf2-page-object-model (issue_267_headless_chrome_support)
$ radon cc page_objects/DriverFactory.py -a
page_objects/DriverFactory.py
    M 145:4 DriverFactory.run_mobile - C
    M 98:4 DriverFactory.run_local - B
    M 49:4 DriverFactory.run_browserstack - B
    M 76:4 DriverFactory.run_sauce_lab - B
    C 17:0 DriverFactory - B
    M 26:4 DriverFactory.get_web_driver - A
    M 240:4 DriverFactory.sauce_upload - A
    M 295:4 DriverFactory.set_firefox_profile - A
    M 264:4 DriverFactory.browser_stack_upload - A
    M 19:4 DriverFactory.__init__ - A
    M 126:4 DriverFactory.get_headless_chrome_options - A
    M 282:4 DriverFactory.get_firefox_driver - A
    M 289:4 DriverFactory.get_firefox_profile - A
```
