### PR TITLE
Fixed no module pytest result log issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest>=6.1.0
 selenium==3.13.0
 python_dotenv==0.8.2
 Appium_Python_Client==0.28
-pytest-xdist==1.22
+pytest-xdist==1.31
 pytest-rerunfailures>=9.1.1
 pytest_reportportal==1.10.0
 pillow>=6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 requests==2.20.0
-pytest>=5.4.0
+pytest>=6.1.0
 selenium==3.13.0
 python_dotenv==0.8.2
 Appium_Python_Client==0.28
 pytest-xdist==1.22
-pytest-rerunfailures==4.1
+pytest-rerunfailures>=9.1.1
 pytest_reportportal==1.10.0
 pillow>=6.2.0
 tesults


### PR DESCRIPTION
Fixed no module pytest result log issue by updating pytest and pytest_reportportal versions