### PR TITLE
Fix pytest issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ pytest>=6.1.0
 selenium==3.13.0
 python_dotenv==0.8.2
 Appium_Python_Client==0.28
-pytest-xdist==1.22
+pytest-xdist>=1.31
+pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1
 pytest_reportportal==1.10.0
 pillow>=6.2.0


### PR DESCRIPTION
The following issue is because the pytest-html is not installed. Maybe its a dependency with other module. I updated the requirements.txt to exclusively install this so no one else runs into it.
```
"ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --html=log/pytest_report.html --self-contained-html" 
```
Another issue occurs while using pytest:
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "C:\Users\Sravanti\coding\pytest\lib\site-packages\_pytest\main.py", line 257, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
.....
Replacing crashed slave gw2`
[gw7] win32 Python 3.7.4 cwd: C:\Users\Sravanti\coding\qxf2-page-object-model
[gw3] node down: Traceback (most recent call last):
  File "C:\Users\Sravanti\coding\pytest\lib\site-packages\execnet\gateway_base.py", line 1400, in _save
    dispatch = self._dispatch[tp]
KeyError: <enum 'ExitCode'>
```
pytest-xdist version. 1.29.0 was released explicitly to support the ExitCode enum. And is fixed with 1.31. 

The branch fix_pytest_issues has 2 commits:
pytest-html==3.0.0 to handle the report.html issue
pytest-xdist==1.31 to fix the INTERNALERROR 
