### PR TITLE
Added interactive mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -149,6 +149,12 @@ a)py.test [options]
 	--slack_flag	used to post pytest reports on the Slack channel		E.g: python -m pytest --slack_flag Y -v > log/pytest_report.log
 	-n 	used to run tests in parallel					E.g: python -m pytest -n 3 -v (This will run three tests in parallel)
 	--tesults 	used to report test results to tesults			E.g: python -m pytest test_example_form.py --tesults Y(This will report test report to tesults)
+	--interactive_mode_flag	used to run the tests interactively
+		E.g:  python -m pytest tests/test_example_form.py --interactive_mode_flag Y(This option will allow the user to pick the desired configuration to run the test, from the menu displayed)
+
+	Note: If you wish to run the test with interactive mode on git bash for windows, please make sure to set your bash alias by adding the following command to bash_rc `alias python='winpty python.exe'`
+
+
 
 b)python tests/test_example_form.py (can also be used to run standalone test)
 

--- a/conf/api_example_conf.py
+++ b/conf/api_example_conf.py
@@ -1,4 +1,5 @@
 #Conf for api example
+api_url="http://127.0.0.1:5000"
 
 #add_car
 car_details = {'name':'figo','brand':'ford','price_range':'5-8 lacs','car_type':'hatchback'}

--- a/conftest.py
+++ b/conftest.py
@@ -3,15 +3,25 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from page_objects.PageFactory import PageFactory
 from conf import browser_os_name_conf
 from conf import base_url_conf
+from conf import api_example_conf
 from conf import report_portal_conf
 from utils import post_test_reports_to_slack
 from utils.email_pytest_report import Email_Pytest_Report
+from endpoints.API_Player import API_Player
 from utils import Tesults
+from utils import interactive_mode
+import argparse
 
 @pytest.fixture
-def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name,testname,reportportal_service):
+def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag,test_run_id,remote_project_name,remote_build_name,testname,reportportal_service,interactivemode_flag):
     "Return an instance of Base Page that knows about the third party integrations"
     try:
+
+        if interactivemode_flag.lower() == "y":
+            default_flag = interactive_mode.set_default_flag_gui(browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag)
+            if default_flag == False:
+                browser,browser_version,remote_flag,os_name,os_version,testrail_flag,tesults_flag = interactive_mode.ask_questions_gui(browser,browser_version,os_version,os_name,remote_flag,testrail_flag,tesults_flag)
+
         test_obj = PageFactory.get_page_object("Zero",base_url=base_url)
         test_obj.set_calling_module(testname)
         #Setup and register a driver
@@ -33,7 +43,6 @@ def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,tes
             test_obj.set_rp_logger(reportportal_service)
 
         yield test_obj
-
         #Teardown
         test_obj.wait(3)
         test_obj.teardown()
@@ -42,12 +51,16 @@ def test_obj(base_url,browser,browser_version,os_version,os_name,remote_flag,tes
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
-def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, test_run_id,app_name,app_path,appium_version):
+def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, test_run_id,app_name,app_path,appium_version,interactivemode_flag):
 
     "Return an instance of Base Page that knows about the third party integrations"
     try:
+
+        if interactivemode_flag.lower()=="y":
+
+            mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, app_name, app_path=interactive_mode.ask_questions_mobile(mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag, tesults_flag, app_name, app_path)
+
         test_mobile_obj = PageFactory.get_page_object("Zero mobile")
 
         #Setup and register a driver
@@ -75,6 +88,20 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
+@pytest.fixture
+def test_api_obj(interactivemode_flag,api_url=api_example_conf.api_url):
+    "Return an instance of Base Page that knows about the third party integrations"
+    try:
+        if interactivemode_flag.lower()=='y':
+            api_url,session_flag = interactive_mode.ask_questions_api(api_url)
+            test_api_obj = API_Player(api_url, session_flag)
+        else:
+            test_api_obj = API_Player(url=api_url, session_flag=True)
+        yield test_api_obj
+
+    except Exception as e:
+        print("Exception when trying to run test:%s" % __file__)
+        print("Python says:%s" % str(e))
 
 @pytest.fixture
 def testname(request):
@@ -89,7 +116,6 @@ def testname(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def browser(request):
     "pytest fixture for browser"
@@ -99,7 +125,6 @@ def browser(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def base_url(request):
@@ -111,7 +136,6 @@ def base_url(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def api_url(request):
     "pytest fixture for base url"
@@ -121,7 +145,6 @@ def api_url(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def test_run_id(request):
@@ -133,7 +156,6 @@ def test_run_id(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def testrail_flag(request):
     "pytest fixture for test rail flag"
@@ -143,7 +165,6 @@ def testrail_flag(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def remote_flag(request):
@@ -155,7 +176,6 @@ def remote_flag(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def browser_version(request):
     "pytest fixture for browser version"
@@ -165,7 +185,6 @@ def browser_version(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def os_name(request):
@@ -177,7 +196,6 @@ def os_name(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def os_version(request):
     "pytest fixture for os version"
@@ -187,7 +205,6 @@ def os_version(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def remote_project_name(request):
@@ -199,7 +216,6 @@ def remote_project_name(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def remote_build_name(request):
     "pytest fixture for browserStack build name"
@@ -209,7 +225,6 @@ def remote_build_name(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def slack_flag(request):
@@ -221,7 +236,6 @@ def slack_flag(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def tesults_flag(request):
     "pytest fixture for sending results to tesults"
@@ -231,7 +245,6 @@ def tesults_flag(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def mobile_os_name(request):
@@ -243,7 +256,6 @@ def mobile_os_name(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def mobile_os_version(request):
     "pytest fixture for mobile os version"
@@ -253,7 +265,6 @@ def mobile_os_version(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def device_name(request):
@@ -265,7 +276,6 @@ def device_name(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def app_package(request):
     "pytest fixture for app package"
@@ -275,7 +285,6 @@ def app_package(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def app_activity(request):
@@ -287,7 +296,6 @@ def app_activity(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def device_flag(request):
     "pytest fixture for device flag"
@@ -297,7 +305,6 @@ def device_flag(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def email_pytest_report(request):
@@ -309,7 +316,6 @@ def email_pytest_report(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def app_name(request):
     "pytest fixture for app name"
@@ -320,7 +326,6 @@ def app_name(request):
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
 
-
 @pytest.fixture
 def ud_id(request):
     "pytest fixture for iOS udid"
@@ -330,7 +335,6 @@ def ud_id(request):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
 
 @pytest.fixture
 def org_id(request):
@@ -383,6 +387,16 @@ def app_path(request):
         print("Python says:%s"%str(e))
 
 @pytest.fixture
+def interactivemode_flag(request):
+    "pytest fixture for questionary module"
+    try:
+        return request.config.getoption("--interactive_mode_flag")
+
+    except Exception as e:
+        print("Exception when trying to run test: %s"%__file__)
+        print("Python says:%s"%str(e))
+
+@pytest.fixture
 def reportportal_service(request):
     "pytest service fixture for reportportal"
     reportportal_pytest_service = None
@@ -394,6 +408,7 @@ def reportportal_service(request):
         print("Python says:%s"%str(e))
 
     return reportportal_pytest_service
+
 
 @pytest.hookimpl()
 def pytest_configure(config):
@@ -462,9 +477,6 @@ def pytest_generate_tests(metafunc):
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
-
-
-
 
 def pytest_addoption(parser):
     "Method to add the option to ini."
@@ -585,6 +597,11 @@ def pytest_addoption(parser):
                             dest="appium_version",
                             help="The appium version if its run in BrowserStack",
                             default="1.17.0")
+
+        parser.addoption("--interactive_mode_flag",
+                            dest="questionary",
+                            default="n",
+                            help="set the questionary flag")
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -10,6 +10,10 @@ from utils.results import Results
 import urllib.parse
 import logging
 from conf import api_example_conf as conf
+from utils import interactive_mode
+import pytest
+from _pytest import python
+from _pytest import config
 
 
 class API_Player(Results):
@@ -17,9 +21,15 @@ class API_Player(Results):
 
     def __init__(self, url, log_file_path=None, session_flag=False):
         "Constructor"
+
         super(API_Player, self).__init__(
             level=logging.DEBUG, log_file_path=log_file_path)
         self.api_obj = API_Interface(url=url, session_flag=session_flag)
+
+    def set_url(self,url):
+
+        self.url=url
+        return self.url
 
 
     def set_auth_details(self, username, password):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ pillow>=6.2.0
 tesults
 loguru
 imageio
-
-
+questionary>=1.9.0
+clear-screen>=0.1.14
+prompt-toolkit==2.0.10

--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -18,110 +18,109 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from endpoints.API_Player import API_Player
 from conf import api_example_conf as conf
+from conftest import interactivemode_flag
 
 @pytest.mark.API
-def test_api_example(api_url='http://127.0.0.1:5000'):
+def test_api_example(test_api_obj):
     "Run api test"
     try:
-        # Create test object
-        test_obj = API_Player(url=api_url, session_flag=True)
         expected_pass = 0
         actual_pass = -1
 
         # set authentication details
         username = conf.user_name
         password = conf.password
-        auth_details = test_obj.set_auth_details(username, password)
+        auth_details = test_api_obj.set_auth_details(username, password)
 
-        initial_car_count = test_obj.get_car_count(auth_details)
+        initial_car_count = test_api_obj.get_car_count(auth_details)
 
 
         # add cars
         car_details = conf.car_details
-        result_flag = test_obj.add_car(car_details=car_details,
-                                          auth_details=auth_details)
-        test_obj.log_result(result_flag,
-                               positive='Successfully added new car with details %s' % car_details,
-                               negative='Could not add new car with details %s' % car_details)
+        result_flag = test_api_obj.add_car(car_details=car_details,
+                                            auth_details=auth_details)
+        test_api_obj.log_result(result_flag,
+                                positive='Successfully added new car with details %s' % car_details,
+                                negative='Could not add new car with details %s' % car_details)
 
 
 
         # Get Cars and verify if new car is added
-        result_flag = test_obj.get_cars(auth_details)
+        result_flag = test_api_obj.get_cars(auth_details)
 
-        result_flag = test_obj.verify_car_count(expected_count=initial_car_count+1,
+        result_flag = test_api_obj.verify_car_count(expected_count=initial_car_count+1,
                                                 auth_details=auth_details)
-        test_obj.log_result(result_flag,
+        test_api_obj.log_result(result_flag,
                             positive='Total car count matches expected count',
                             negative='Total car count doesnt match expected count')
 
         # Update car
         update_car = conf.update_car
         update_car_name = conf.car_name_2
-        result_flag = test_obj.update_car(auth_details=auth_details,
-                                          car_name=update_car_name,
-                                          car_details=update_car)
-        test_obj.log_result(result_flag,
+        result_flag = test_api_obj.update_car(auth_details=auth_details,
+                                            car_name=update_car_name,
+                                            car_details=update_car)
+        test_api_obj.log_result(result_flag,
                             positive='Successfully updated car : %s' % update_car_name,
                             negative='Couldnt update car :%s' % update_car_name)
 
         # Get one car details
         new_car = conf.car_name_1
         brand = conf.brand
-        result_flag = test_obj.get_car(auth_details=auth_details,
-                                       car_name=new_car,
-                                       brand=brand)
-        test_obj.log_result(result_flag,
+        result_flag = test_api_obj.get_car(auth_details=auth_details,
+                                        car_name=new_car,
+                                        brand=brand)
+        test_api_obj.log_result(result_flag,
                             positive='Successfully fetched car details of car : %s' % new_car,
                             negative='Couldnt fetch car details of car :%s' % new_car)
 
         # Register car
         customer_details = conf.customer_details
-        result_flag = test_obj.register_car(auth_details=auth_details,
+        result_flag = test_api_obj.register_car(auth_details=auth_details,
                                             car_name=new_car,
                                             brand=brand)
-        test_obj.log_result(result_flag,
+        test_api_obj.log_result(result_flag,
                             positive='Successfully registered new car %s with customer details %s' % (new_car, customer_details),
                             negative='Couldnt register new car %s with cutomer details %s' % (new_car, customer_details))
 
         #Get Registered cars and check count
-        result_flag = test_obj.get_registered_cars(auth_details)
-        register_car_count = test_obj.get_regi_car_count(auth_details)
+        result_flag = test_api_obj.get_registered_cars(auth_details)
+        register_car_count = test_api_obj.get_regi_car_count(auth_details)
 
-        result_flag = test_obj.verify_registration_count(expected_count=register_car_count,
-                                                         auth_details=auth_details)
-        test_obj.log_result(result_flag,
+        result_flag = test_api_obj.verify_registration_count(expected_count=register_car_count,
+                                                            auth_details=auth_details)
+        test_api_obj.log_result(result_flag,
                             positive='Registered count matches expected value',
                             negative='Registered car count doesnt match expected value')
 
         # Remove newly added car
-        result_flag = test_obj.remove_car(auth_details=auth_details,
-                                          car_name=update_car_name)
-        test_obj.log_result(result_flag,
+        result_flag = test_api_obj.remove_car(auth_details=auth_details,
+                                            car_name=update_car_name)
+        test_api_obj.log_result(result_flag,
                             positive='Successfully deleted car %s' % update_car,
                             negative='Could not delete car %s ' % update_car)
 
         # validate if car is deleted
-        result_flag = test_obj.verify_car_count(expected_count=initial_car_count,
+        result_flag = test_api_obj.verify_car_count(expected_count=initial_car_count,
                                                 auth_details=auth_details)
-        test_obj.log_result(result_flag,
+        test_api_obj.log_result(result_flag,
                             positive='Total car count matches expected count after deleting one car',
                             negative='Total car count doesnt match expected count after deleting one car')
 
         # Deleting registered car
-        test_obj.delete_registered_car(auth_details)
+        test_api_obj.delete_registered_car(auth_details)
 
         # test for validation http error 403
-        result = test_obj.check_validation_error(auth_details)
+        result = test_api_obj.check_validation_error(auth_details)
 
-        test_obj.log_result(not result['result_flag'],
+        test_api_obj.log_result(not result['result_flag'],
                             positive=result['msg'],
                             negative=result['msg'])
 
         # test for validation http error 401 when no authentication
         auth_details = None
-        result = test_obj.check_validation_error(auth_details)
-        test_obj.log_result(not result['result_flag'],
+        result = test_api_obj.check_validation_error(auth_details)
+        test_api_obj.log_result(not result['result_flag'],
                             positive=result['msg'],
                             negative=result['msg'])
 
@@ -129,27 +128,27 @@ def test_api_example(api_url='http://127.0.0.1:5000'):
         # set invalid authentication details
         username = conf.invalid_user_name
         password = conf.invalid_password
-        auth_details = test_obj.set_auth_details(username, password)
-        result = test_obj.check_validation_error(auth_details)
-        test_obj.log_result(not result['result_flag'],
+        auth_details = test_api_obj.set_auth_details(username, password)
+        result = test_api_obj.check_validation_error(auth_details)
+        test_api_obj.log_result(not result['result_flag'],
                             positive=result['msg'],
                             negative=result['msg'])
 
         # write out test summary
-        expected_pass = test_obj.total
-        actual_pass = test_obj.passed
-        test_obj.write_test_summary()
+        expected_pass = test_api_obj.total
+        actual_pass = test_api_obj.passed
+        test_api_obj.write_test_summary()
 
     except Exception as e:
         print(e)
-        if api_url=='http://127.0.0.1:5000':
-            test_obj.write("Please run the test against http://35.167.62.251/ by changing the api_url in test_api_example.py")
-            test_obj.write("OR")
-            test_obj.write("Clone the repo 'https://github.com/qxf2/cars-api.git' and run the cars_app inorder to run the test against your system")
+        if conf.api_url == 'http://127.0.0.1:5000':
+            test_api_obj.write("Please run the test against http://35.167.62.251/ by changing the api_url in api_example_conf.py")
+            test_api_obj.write("OR")
+            test_api_obj.write("Clone the repo 'https://github.com/qxf2/cars-api.git' and run the cars_app inorder to run the test against your system")
 
         else:
-            test_obj.write("Exception when trying to run test:%s" % __file__)
-            test_obj.write("Python says:%s" % str(e))
+            test_api_obj.write("Exception when trying to run test:%s" % __file__)
+            test_api_obj.write("Python says:%s" % str(e))
 
     # Assertion
     assert expected_pass == actual_pass,"Test failed: %s"%__file__

--- a/utils/interactive_mode.py
+++ b/utils/interactive_mode.py
@@ -1,0 +1,595 @@
+"""
+Implementing the questionaty library to fetch the users choices for different arguments
+"""
+import sys
+import questionary
+from clear_screen import clear
+from conf import api_example_conf
+from conf import browser_os_name_conf as conf
+from conf import remote_credentials
+
+def display_gui_test_options(browser,browser_version,os_version,
+                             os_name,remote_flag,testrail_flag,tesults_flag):
+    "Displays the selected options to run the GUI test"
+    print("Browser selected:",browser)
+    if browser_version == []:
+        print("Browser version selected: None")
+    else:
+        print("Browser version selected:",browser_version)
+    if os_name == []:
+        print("OS selected: None")
+    else:
+        print("OS selected:",os_name)
+    if os_version == []:
+        print("OS version selected: None")
+    else:
+        print("OS version selected:",os_version)
+    print("Remote flag status:",remote_flag)
+    print("Testrail flag status:",testrail_flag)
+    print("Tesults flag status:",tesults_flag)
+
+def set_default_flag_gui(browser,browser_version,os_version,os_name,
+                         remote_flag,testrail_flag,tesults_flag):
+    "This checks if the user wants to run the test with the default options or no"
+
+    questionary.print("\nDefault Options",style="bold fg:green")
+    questionary.print("**********",style="bold fg:green")
+    display_gui_test_options(browser,browser_version,os_version,
+                             os_name,remote_flag,testrail_flag,tesults_flag)
+    questionary.print("**********",style="bold fg:green")
+
+    default = questionary.select("Do you want to run the test with the default set of options?",
+                                  choices=["Yes","No"]).ask()
+    default_flag = True if default == "Yes" else False
+
+    return default_flag
+
+def get_user_response_gui():
+    "Get response from user for GUI tests"
+    response = questionary.select("What would you like to change?",
+                                   choices=["Browser","Browser Version","Os Version",
+                                   "Os Name","Remote flag status","Testrail flag status",
+                                   "Tesults flag status","Set Remote credentials",
+                                   "Revert back to default options","Run","Exit"]).ask()
+
+    return response
+
+def ask_questions_gui(browser,browser_version,os_version,os_name,remote_flag,
+                      testrail_flag,tesults_flag):
+    """This module asks the users questions on what options they wish to run
+       the test with and stores their choices"""
+    clear()
+    while True:
+        questionary.print("\nUse up and down arrow keys to switch between options.\
+                           \nUse Enter key to select an option",
+                           style="bold fg:yellow")
+        questionary.print("\nSelected Options",style="bold fg:green")
+        questionary.print("**********",style="bold fg:green")
+        display_gui_test_options(browser, browser_version, os_version, os_name,
+                                 remote_flag, testrail_flag, tesults_flag)
+        questionary.print("**********",style="bold fg:green")
+        response = get_user_response_gui()
+        clear()
+        if response == "Browser":
+            browser=questionary.select("Select the browser",
+                                        choices=conf.browsers).ask()
+            browser_version = []
+            if remote_flag == "Y":
+                questionary.print("Please select the browser version",
+                                   style="bold fg:darkred")
+
+        if response == "Browser Version":
+            if remote_flag == "Y":
+                browser_version = get_browser_version(browser)
+            else:
+                questionary.print("Browser version can be selected only when running the test remotely.\
+                                   \nPlease change the remote flag status inorder to use this option",
+                                   style="bold fg:red")
+
+        if response == "Remote flag status":
+            remote_flag = get_remote_flag_status()
+            if remote_flag == "Y":
+                browser = "chrome"
+                os_name = "Windows"
+                os_version = "10"
+                browser_version = "65"
+                questionary.print("The default remote test options has been selected",
+                                   style="bold fg:green")
+
+        if response == "Os Version":
+            os_version = get_os_version(os_name)
+
+        if response == "Os Name":
+            if remote_flag == "Y":
+                os_name, os_version = get_os_name(remote_flag)
+            else:
+                questionary.print("OS Name can be selected only when running the test remotely.\
+                                  \nPlease change the remote flag status inorder to use this option",
+                                   style="bold fg:red")
+
+        if response == "Testrail flag status":
+            testrail_flag = get_testrailflag_status()
+
+        if response == "Tesults flag status":
+            tesults_flag = get_tesultsflag_status()
+
+        if response == "Set Remote credentials":
+            set_remote_credentials()
+
+        if response == "Revert back to default options":
+            browser, os_name, os_version,  browser_version, remote_flag, testrail_flag, tesults_flag = gui_default_options()
+            questionary.print("Reverted back to the default options",style="bold fg:green")
+
+        if response == "Run":
+            if remote_flag == "Y":
+                if browser_version == []:
+                    questionary.print("Please select the browser version before you run the test",
+                                       style="bold fg:darkred")
+                elif os_version == []:
+                    questionary.print("Please select the OS version before you run the test",
+                                       style="bold fg:darkred")
+                else:
+                    break
+            else:
+                break
+
+        if response == "Exit":
+            sys.exit("Program interrupted by user, Exiting the program....")
+
+    return browser,browser_version,remote_flag,os_name,os_version,testrail_flag,tesults_flag
+
+def ask_questions_mobile(mobile_os_name, mobile_os_version, device_name, app_package,
+                         app_activity, remote_flag, device_flag, testrail_flag, tesults_flag,
+                         app_name, app_path):
+    """This module asks the users questions to fetch the options they wish to run the mobile
+       test with and stores their choices"""
+    clear()
+    while True:
+        questionary.print("\nUse up and down arrow keys to switch between options.\
+                           \nUse Enter key to select an option",
+                           style="bold fg:yellow")
+        mobile_display_options(mobile_os_name, mobile_os_version, device_name,
+                               app_package, app_activity, remote_flag, device_flag,
+                               testrail_flag, tesults_flag, app_name, app_path)
+        questionary.print("**********",style="bold fg:green")
+        response = get_user_response_mobile()
+        clear()
+        if response == "Mobile OS Name":
+            mobile_os_name, mobile_os_version, device_name = get_mobile_os_name()
+
+        if response == "Mobile OS Version":
+            mobile_os_version = get_mobile_os_version(mobile_os_name)
+
+        if response=="Device Name":
+
+            if mobile_os_name == "Android":
+                device_name = mobile_android_devices(mobile_os_version)
+
+            if mobile_os_name == "iOS":
+                device_name = mobile_ios_devices(mobile_os_version)
+
+        if response == "App Package":
+            app_package = questionary.text("Enter the app package name").ask()
+
+        if response == "App Activity":
+            app_package=questionary.text("Enter the App Activity").ask()
+
+        if response == "Set Remote credentials":
+            set_remote_credentials()
+
+        if response == "Remote Flag status":
+            remote_flag = get_remote_flag_status()
+
+        if response == "Testrail Flag status":
+            testrail_flag = get_testrailflag_status()
+
+        if response == "Tesults Flag status":
+            tesults_flag = get_tesultsflag_status()
+
+        if response == "App Name":
+            app_name = questionary.text("Enter App Name").ask()
+
+        if response == "App Path":
+            app_path = questionary.path("Enter the path to your app").ask()
+
+        if response == "Revert back to default options":
+            mobile_os_name, mobile_os_version, device_name, app_package, app_activity, remote_flag, device_flag, testrail_flag,tesults_flag, app_name, app_path = mobile_default_options()
+
+        if response == "Run":
+            if app_path is None:
+                questionary.print("Please enter the app path before you run the test",
+                                   style="bold fg:darkred")
+            else:
+                break
+
+        if response == "Exit":
+            sys.exit("Program interrupted by user, Exiting the program....")
+
+    return (mobile_os_name, mobile_os_version, device_name, app_package,
+            app_activity, remote_flag, device_flag, testrail_flag, tesults_flag,
+            app_name,app_path)
+
+def get_user_response_mobile():
+    "Get response from user for mobile tests"
+    response = questionary.select("What would you like to change?",
+                                   choices=["Mobile OS Name","Mobile OS Version",
+                                   "Device Name","App Package","App Activity",
+                                   "Set Remote credentials","Remote Flag status",
+                                   "Testrail flag status","Tesults flag status",
+                                   "App Name","App Path",
+                                   "Revert back to default options",
+                                   "Run","Exit"]).ask()
+
+    return response
+
+def ask_questions_api(api_url,session_flag=True):
+    """This module asks the users questions to fetch the options
+       they wish to run the api test with and stores their choices"""
+    clear()
+    while True:
+
+        questionary.print("\nSeleted Options",style="bold fg:green")
+        questionary.print("**********",style="bold fg:green")
+        print("API URL:",api_url)
+        print("Session flag status:",session_flag)
+        questionary.print("**********",style="bold fg:green")
+        response = get_user_response_api()
+        clear()
+        if response == "Session flag status":
+            session_flag = get_sessionflag_status()
+
+        if response == "API URL":
+            api_url = get_api_url()
+
+        if response == "Reset back to default settings":
+            api_url = api_example_conf.api_url
+            session_flag = True
+            questionary.print("Reverted back to default settings",
+                               style="bold fg:green")
+
+        if response == "Run":
+            break
+
+        if response == "Exit":
+            sys.exit("Program interrupted by user, Exiting the program....")
+
+    return api_url,str(session_flag)
+
+def get_user_response_api():
+    "Get response from user for api tests"
+    response=questionary.select("What would you like to change",
+                                 choices=["API URL","Session flag status",
+                                          "Reset back to default settings",
+                                          "Run","Exit"]).ask()
+
+    return response
+
+def get_testrailflag_status():
+    "Get the testrail flag status"
+    testrail_flag = questionary.select("Enter the testrail flag",
+                                        choices=["Yes","No"]).ask()
+
+    if testrail_flag == "Yes":
+        testrail_flag = "Y"
+    else:
+        testrail_flag = "N"
+
+    return testrail_flag
+
+def get_tesultsflag_status():
+    "Get tesults flag status"
+    tesults_flag = questionary.select("Enter the tesults flag",
+                                       choices=["Yes","No"]).ask()
+
+    if tesults_flag == "Yes":
+        tesults_flag = "Y"
+    else:
+        tesults_flag = "N"
+
+    return tesults_flag
+
+def set_remote_credentials():
+    "set remote credentials file to run the test on browserstack or saucelabs"
+    platform = questionary.select("Select the remote platform on which you wish to run the test on",
+                                   choices=["Browserstack","Saucelabs"]).ask()
+    if platform == "Browserstack":
+        platform = "BS"
+    else:
+        platform = "SL"
+    username = questionary.text("Enter the Username").ask()
+    password = questionary.password("Enter the password").ask()
+    with open("conf/remote_credentials.py",'w') as cred_file:
+        cred_file.write("REMOTE_BROWSER_PLATFORM = '%s'\
+                         \nUSERNAME = '%s'\
+                         \nACCESS_KEY = '%s'"%(platform,username,password))
+    questionary.print("Updated the credentials successfully",
+                       style="bold fg:green")
+
+def get_remote_flag_status():
+    "Get the remote flag status"
+    remote_flag = questionary.select("Select the remote flag status",
+                                      choices=["Yes","No"]).ask()
+    if remote_flag == "Yes":
+        remote_flag = "Y"
+    else:
+        remote_flag = "N"
+
+    return remote_flag
+
+def get_browser_version(browser):
+    "Get the browser version"
+    if browser == "chrome":
+        browser_version=questionary.select("Select the browser version",
+                                            choices=conf.chrome_versions).ask()
+
+    elif browser == "firefox":
+        browser_version=questionary.select("Select the browser version",
+                                            choices=conf.firefox_versions).ask()
+
+    elif browser == "safari":
+        browser_version = questionary.select("Select the browser version",
+                                              choices=conf.safari_versions).ask()
+
+    return browser_version
+
+def get_os_version(os_name):
+    "Get OS Version"
+    if os_name == "windows":
+        os_version = questionary.select("Select the OS version",
+                                         choices=conf.windows_versions).ask()
+    elif os_name == "OS X":
+        if remote_credentials.REMOTE_BROWSER_PLATFORM == "SL":
+            os_version = questionary.select("Select the OS version",
+                                             choices=conf.sauce_labs_os_x_versions).ask()
+        else:
+            os_version = questionary.select("Select the OS version",
+                                             choices=conf.os_x_versions).ask()
+    else:
+        os_version= []
+        questionary.print("Please select the OS Name first",
+                           style="bold fg:darkred")
+
+    return os_version
+
+def get_os_name(remote_flag):
+    "Get OS Name"
+    os_name = questionary.select("Enter the OS version",choices=conf.os_list).ask()
+    os_version = []
+    if remote_flag == "Y":
+        questionary.print("Please select the OS Version",style="bold fg:darkred")
+
+    return os_name, os_version
+
+def gui_default_options():
+    "The default options for GUI tests"
+    browser = conf.default_browser[0]
+    os_name = []
+    os_version = []
+    browser_version = []
+    remote_flag = "N"
+    testrail_flag = "N"
+    tesults_flag = "N"
+
+    return browser, os_name, os_version,  browser_version, remote_flag, testrail_flag, tesults_flag
+
+def  mobile_display_options(mobile_os_name, mobile_os_version, device_name,
+                            app_package, app_activity, remote_flag, device_flag,
+                            testrail_flag, tesults_flag, app_name,app_path):
+    "Display the selected options for mobile tests"
+    print("Mobile OS Name:",mobile_os_name)
+    print("Mobile OS Version:",mobile_os_version)
+    print("Device Name:",device_name)
+    print("App Package:",app_package)
+    print("App Activity:",app_activity)
+    print("Remote Flag status:",remote_flag)
+    print("Device Flag status:",device_flag)
+    print("Testrail Flag status:",testrail_flag)
+    print("Tesults Flag status:",tesults_flag)
+    print("App Name:",app_name)
+    print("App Path:",app_path)
+
+def mobile_android_devices(mobile_os_version):
+    "Get device name for android devices"
+    questionary.print("The devices that support Android %s has been listed.\
+                       \nPlease select any one device"%(mobile_os_version),
+                       style="bold fg:green")
+    if mobile_os_version == "10.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy S20",
+                                          "Samsung Galaxy Note 20", "Google Pixel 4",
+                                          "Google Pixel 3","OnePlus 8",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "9.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy S10",
+                                          "Samsung Galaxy A51", "Google Pixel 3a",
+                                          "Xiaomi Redmi Note 8","OnePlus 7",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "8.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy S9",
+                                          "Google Pixel 2",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "8.1":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy Note 9",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "7.1":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy Note 8",
+                                          "Google Pixel","Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "7.0":
+        device_name=questionary.select("Select the device name",
+                                        choices=["Samsung Galaxy S8",
+                                        "Google Nexus 6P", "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "6.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["Samsung Galaxy S7",
+                                          "Google Nexus 6","Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    else:
+        device_name = questionary.text("Enter the Device name").ask()
+
+    return device_name
+
+def mobile_ios_devices(mobile_os_version):
+    "Get device name for ios devices"
+    questionary.print("The devices that support iOS %s has been listed.\
+                       \nPlease select any one device"%(mobile_os_version),
+                       style = "bold fg:green")
+    if mobile_os_version == "8.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 6",
+                                          "iPhone 6 Plus",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "9.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 6S","iPhone 6S Plus",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "10.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 7",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "11.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 6","iPhone 6S",
+                                          "iPhone 6S Plus","iPhone SE",
+                                          "Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "12.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 7","iPhone 8",
+                                          "iPhone XS","Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "13.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 11","iPhone 11 Pro",
+                                          "iPhone 8","Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    elif mobile_os_version == "14.0":
+        device_name = questionary.select("Select the device name",
+                                          choices=["iPhone 11","iPhone 12",
+                                          "iPhone 12 Pro","Other Devices"]).ask()
+        if device_name == "Other Devices":
+            device_name = questionary.text("Enter the device name").ask()
+
+    else:
+        device_name = questionary.text("Enter the Device name").ask()
+
+    return device_name
+
+def mobile_default_options():
+    "The default options for mobile tests"
+    mobile_os_name = "Android"
+    mobile_os_version = "8.0"
+    device_name = "Samsung Galaxy S9"
+    app_package = "com.dudam.rohan.bitcoininfo"
+    app_activity = ".MainActivity"
+    remote_flag = "N"
+    device_flag = "N"
+    testrail_flag = "N"
+    tesults_flag = "N"
+    app_name = "Bitcoin Info_com.dudam.rohan.bitcoininfo.apk"
+    app_path = None
+
+    return (mobile_os_name, mobile_os_version, device_name, app_package,
+            app_activity, remote_flag, device_flag, testrail_flag,
+            tesults_flag, app_name, app_path)
+
+def get_mobile_os_name():
+    "Get the mobile OS name"
+    mobile_os_name=questionary.select("Select the Mobile OS",
+                                       choices=["Android","iOS"]).ask()
+
+    if mobile_os_name == "Android":
+        mobile_os_version = "8.0"
+        device_name = "Samsung Galaxy S9"
+        questionary.print("The default os version and device for Android has been selected.\
+                           \nYou can change it as desired from the menu",
+                           style="bold fg:green")
+    if mobile_os_name == "iOS":
+        mobile_os_version = "8.0"
+        device_name = "iPhone 6"
+        questionary.print("The default os version and device for iOS has been selected.\
+                           \nYou can change it as desired from the menu",
+                           style="bold fg:green")
+
+    return mobile_os_name, mobile_os_version, device_name
+
+def get_mobile_os_version(mobile_os_name):
+    "Get mobile OS version"
+    if mobile_os_name == "Android":
+        mobile_os_version = questionary.select("Select the Mobile OS version",
+                                                choices=["6.0","7.0","7.1",
+                                                "8.0","8.1","9.0",
+                                                "Other versions"]).ask()
+
+    elif mobile_os_name == "iOS":
+        mobile_os_version = questionary.select("Select the Mobile OS version",
+                                                choices=["8.0","9.0","10.0","11.0",
+                                                "12.0","13.0","14.0",
+                                                "Other versions"]).ask()
+
+    if mobile_os_version == "Other versions":
+        mobile_os_version = questionary.text("Enter the OS version").ask()
+
+    return mobile_os_version
+
+def get_sessionflag_status():
+    "Get the session flag status"
+    session_flag=questionary.select("Select the Session flag status",
+                                     choices=["True","False"]).ask()
+    if session_flag == "True":
+        session_flag = True
+    if session_flag == "False":
+        session_flag = False
+
+    return session_flag
+
+def get_api_url():
+    "Get the API URL"
+    api_url = questionary.select("Select the API url",
+                                  choices=["localhost",
+                                  "http://35.167.62.251/",
+                                  "Enter the URL manually"]).ask()
+    if api_url == "localhost":
+        api_url = api_example_conf.api_url
+    if api_url == "Enter the URL manually":
+        api_url = questionary.text("Enter the url").ask()
+
+    return api_url


### PR DESCRIPTION
This is a new feature that allows the user to run the tests interactively via the terminal.
Steps to run:

If you're using Gitbash for windows please make sure to set your bash alias by adding the following command to your bash_rc file alias python='winpty python.exe'
Install the requirements using pip install -r reqquirements.txt
Commands to run the test :
python -m pytest tests/test_example_form.py --interactivemode_flag Y
python -m pytest tests/test_mobile_bitcoin_price.py --interactivemode_flag Y
python -m pytest tests/test_api_example.py --interactivemode_flag Y
Changes made:
A new feature to run the tests interactive using --interactivemode_flag
A new pytest fixture test_api_obj in contest file for API tests
Importing the API URL from a conf file