### PR TITLE
codacy critical issue - no value for argument 'test_api_obj' in function call

### DIFF
--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -152,7 +152,3 @@ def test_api_example(test_api_obj):
 
     # Assertion
     assert expected_pass == actual_pass,"Test failed: %s"%__file__
-
-
-if __name__ == '__main__':
-    test_api_example()


### PR DESCRIPTION
While using codacy to analyse our POM frame work resulting with some issues i.e. critical issue in test_api_example.py - no value for argument 'test_api_obj' in function call , so inorder to resolve the issue removed 'main()' function in the script