### PR TITLE
critical issue - too many arguments for format string

### DIFF
--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -458,7 +458,7 @@ class Base_Page(Borg,unittest.TestCase):
         except Exception as e:
             self.write(str(e),'debug')
             self.write("Error while parsing locator")
-            self.exceptions.append("Unable to split the locator-'%s' in the conf/locators.conf file"%(locator[0],locator[1]))
+            self.exceptions.append("Unable to split the locator-'%s,%s' in the conf/locators.conf file"%(locator[0],locator[1]))
 
         return result
 


### PR DESCRIPTION
* While analyzing the code of POM using codacy hitting with one of the critical issues i.e. too many arguments for format string in page_objects/Base_Page.py (line 461).
* Cause for the issue:
- The format string is unable to split the locator-'%s' in the conf/locators.conf file, which contains only one %s format specifier. However, we are passing two values to the format string in the parentheses, locator[0] and locator[1].
* Fixing the issue:
- Modifying the format string to include a second %s format specifier