### PR TITLE
changing statement to print %str_var instead of %int_var

### DIFF
--- a/utils/string_to_int_util.py
+++ b/utils/string_to_int_util.py
@@ -12,7 +12,7 @@ class String_To_Int():
             int_var = int(str_var)
         except Exception as e:
             print("Error type casting var to int")
-            print("Obtained the %s"%int_var)
+            print("Obtained the %s"%str_var)
             print("Python says: " + str(e))
             return str_var
         return int_var


### PR DESCRIPTION
Codacy finds an issue - Using variable 'int_var' before assignment
Cause for an issue : 
The int_var variable is defined inside the try block, and if an exception occurs in the try block, the int_var variable may not be defined. Therefore, if an exception occurs, attempting to use int_var in the except block will result in a NameError.
Fix for an issue :
Updated the print() statement inside the except block to use the str_var variable instead of int_var to avoid the error of using the int_var variable before it's assigned in the except block.