### PR TITLE
updating version of docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #Dockerfile to build an image for running Selenium tests
 #Pull ubuntu 16.04 base image
-FROM ubuntu
+FROM ubuntu:16.04
 LABEL maintainer = "Qxf2 Services"
 
 # Essential tools and xvfb


### PR DESCRIPTION
* Codacy detected an issue : Always tag the version of an image explicitly.
* To resolve the issue explicitly tagging the image with a specific version for base image (ubuntu:16.04) ensures that application will not break due to random changes across different versions of an image we depend on
* currenty on commit : [e255a80](https://github.com/qxf2/qxf2-page-object-model/commit/e255a80803170fb7817e09078888b21484378870)

