### PR TITLE
delete the apt-get lists after installing something

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     unzip \
     wget \
-    xvfb
+    xvfb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Chrome browser to run the tests
 ARG CHROME_VERSION=latest
@@ -63,4 +65,6 @@ RUN apt-get update
 RUN apt-get install -y \
     python3 \
     python3-setuptools \
-    python3-pip
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* Codacy detected an issue in Dockerfile : `Delete the apt-get lists after installing something`.
* Fixing the issue : cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down. Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install.
* Currently on commit - https://github.com/qxf2/qxf2-page-object-model/commit/630ca6ecc31d47531d6ec346a4e9e4c0add094f2