### PR TITLE
fixing Codacy issues - Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     xterm 
 
 # Chrome browser to run the tests
-ARG CHROME_VERSION=113.0.5672.92
+ARG CHROME_VERSION=113.0.5672.126
 RUN wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && apt-key add /tmp/google.pub && rm /tmp/google.pub && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list && mkdir -p /usr/share/desktop-directories && apt-get -y update && apt-get install -y google-chrome-stable=${CHROME_VERSION}-1 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Disable the SUID sandbox so that chrome can launch without being in a privileged container

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "htt
 ARG GECKODRIVER_VERSION=0.32.2
 RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- 'https://api.github.com/repos/mozilla/geckodriver/releases/latest' | grep '\"tag_name\":' | sed -E 's/.*\"v([0-9.]+)\".*/\1/')"; else echo "$GECKODRIVER_VERSION"; fi)" \
   && echo "Using GeckoDriver version: ""$GK_VERSION" \
-  && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \
+  && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v"$GK_VERSION"/geckodriver-v"$GK_VERSION"-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
   && rm /tmp/geckodriver.tar.gz \
@@ -72,12 +72,8 @@ RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo 
   && chmod 755 /opt/geckodriver-"$GK_VERSION" \
   && ln -fs /opt/geckodriver-"$GK_VERSION" /usr/bin/geckodriver
 
-# Python 3.5 and Python Pip
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-    python3.10 \
-    python3-setuptools=59.6.0-1.2ubuntu0.22.04.1 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.2 \
+# Python 3.10 and Python Pip
+RUN apt-get update && apt-get install -y python3.10 python3-setuptools python3-pip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /o
 
 # Chrome Driver
 ARG CHROME_DRIVER_VERSION=113.0.5672.63
-RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"; else echo "${CHROME_DRIVER_VERSION}"; fi)" \
+RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE')"; else echo "${CHROME_DRIVER_VERSION}"; fi)" \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #Dockerfile to build an image for running Selenium tests
-#Pull ubuntu 16.04 base image
-FROM ubuntu
+#Pull ubuntu 22.04 base image
+FROM ubuntu:22.04
 LABEL maintainer = "Qxf2 Services"
 
 # Essential tools and xvfb
@@ -8,20 +8,23 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     unzip \
     wget \
-    xvfb
-
+    bzip2 \
+    xvfb 
+    
 # Chrome browser to run the tests
 ARG CHROME_VERSION=latest
-RUN if [ ${CHROME_VERSION} = "latest" ]; then wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && cat /tmp/google.pub | apt-key add -; rm /tmp/google.pub  && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list  && mkdir -p /usr/share/desktop-directories  && apt-get -y update && apt-get install -y google-chrome-stable; else wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add && wget https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_$CHROME_VERSION.deb && dpkg -i download-chrome*.deb || true && apt-get install -y -f && rm -rf /var/lib/apt/lists/*;fi
+RUN if [ ${CHROME_VERSION} = "latest" ]; then wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && apt-key add /tmp/google.pub && rm /tmp/google.pub  && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list  && mkdir -p /usr/share/desktop-directories  && apt-get -y update && apt-get install -y google-chrome-stable; else wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add && wget https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_$CHROME_VERSION.deb && dpkg -i download-chrome*.deb || true && apt-get install -y -f && rm -rf /var/lib/apt/lists/*;fi \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Disable the SUID sandbox so that chrome can launch without being in a privileged container
 RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /opt/google/chrome/google-chrome \
-        && echo "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome \
+        && printf "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome \
         && chmod 755 /opt/google/chrome/google-chrome
 
 # Chrome Driver
 ARG CHROME_DRIVER_VERSION=latest
-RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_VERSION; fi) \
+RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo "${CHROME_DRIVER_VERSION}"; fi)" \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
@@ -30,11 +33,17 @@ RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $
   && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
   && ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
 
-RUN if [ ${CHROME_DRIVER_VERSION} != "latest" ]; then mkdir -p /opt/selenium && wget -qO /opt/selenium/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip && cd /opt/selenium; unzip /opt/selenium/chromedriver_linux64.zip; rm -rf chromedriver_linux64.zip; ln -fs /opt/selenium/chromedriver /usr/local/bin/chromedriver;fi
+RUN if [ ${CHROME_DRIVER_VERSION} != "latest" ]; then \
+  mkdir -p /opt/selenium && \
+  wget -qO /opt/selenium/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip && \
+  unzip /opt/selenium/chromedriver_linux64.zip -d /opt/selenium && \
+  rm -rf /opt/selenium/chromedriver_linux64.zip && \
+  ln -fs /opt/selenium/chromedriver /usr/local/bin/chromedriver; \    
+  fi
 
 #Firefox browser to run the tests
 ARG FIREFOX_VERSION=latest
-RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi) \
+RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi)" \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
@@ -44,11 +53,13 @@ RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ]; then echo "https:
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver
 ARG GECKODRIVER_VERSION=latest
-RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo $GECKODRIVER_VERSION; fi) \
+RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo "$GECKODRIVER_VERSION"; fi)" \
   && echo "Using GeckoDriver version: "$GK_VERSION \
   && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
@@ -60,7 +71,9 @@ RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo $(w
 
 # Python 3.5 and Python Pip
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     python3 \
     python3-setuptools \
-    python3-pip
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo 
 # Python 3.5 and Python Pip
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
     python3-setuptools \
     python3-pip \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ ENV DISPLAY=:20
 # Essential tools and xvfb
 RUN apt-get update && apt-get install -y \
     software-properties-common \
-    unzip \
-    wget \
-    bzip2 \
+    unzip=6.00 \
+    wget=1.21.2 \
+    bzip2=1.0.8 \
     xvfb \
-    x11vnc \
-    fluxbox \
+    x11vnc=0.9.16 \
+    fluxbox=1.3.5 \
     xterm
 
 # Chrome browser to run the tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,16 @@ RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /o
 
 # Chrome Driver
 ARG CHROME_DRIVER_VERSION=113.0.5672.63
-RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo "${CHROME_DRIVER_VERSION}"; fi)" \
+RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"; else echo "${CHROME_DRIVER_VERSION}"; fi)" \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
   && rm /tmp/chromedriver_linux64.zip \
-  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CD_VERSION \
-  && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
-  && ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-"$CD_VERSION" \
+  && chmod 755 /opt/selenium/chromedriver-"$CD_VERSION" \
+  && ln -fs /opt/selenium/chromedriver-"$CD_VERSION" /usr/bin/chromedriver
 
-RUN if [ ${CHROME_DRIVER_VERSION} != "113.0.5672.63" ]; then \
+RUN if [ "${CHROME_DRIVER_VERSION}" != "113.0.5672.63" ]; then \
   mkdir -p /opt/selenium && \
   wget -qO /opt/selenium/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip && \
   unzip /opt/selenium/chromedriver_linux64.zip -d /opt/selenium && \
@@ -44,32 +44,32 @@ RUN if [ ${CHROME_DRIVER_VERSION} != "113.0.5672.63" ]; then \
 
 #Firefox browser to run the tests
 ARG FIREFOX_VERSION=109.0
-RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi)" \
+RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-"$FIREFOX_VERSION"-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/"$FIREFOX_VERSION"/linux-x86_64/en-US/firefox-"$FIREFOX_VERSION".tar.bz2"; fi)" \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && apt-get install libdbus-glib-1-2 \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-  && wget --no-verbose -O /tmp/firefox.tar.bz2 $FIREFOX_DOWNLOAD_URL \
+  && wget --no-verbose -O /tmp/firefox.tar.bz2 "$FIREFOX_DOWNLOAD_URL" \
   && apt-get -y purge firefox \
   && rm -rf /opt/firefox \
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox \
+  && ln -fs /opt/firefox-"$FIREFOX_VERSION"/firefox /usr/bin/firefox \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver
 ARG GECKODRIVER_VERSION=0.32.2
-RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo "$GECKODRIVER_VERSION"; fi)" \
-  && echo "Using GeckoDriver version: "$GK_VERSION \
+RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- 'https://api.github.com/repos/mozilla/geckodriver/releases/latest' | grep '\"tag_name\":' | sed -E 's/.*\"v([0-9.]+)\".*/\1/')"; else echo "$GECKODRIVER_VERSION"; fi)" \
+  && echo "Using GeckoDriver version: ""$GK_VERSION" \
   && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
   && rm /tmp/geckodriver.tar.gz \
-  && mv /opt/geckodriver /opt/geckodriver-$GK_VERSION \
-  && chmod 755 /opt/geckodriver-$GK_VERSION \
-  && ln -fs /opt/geckodriver-$GK_VERSION /usr/bin/geckodriver
+  && mv /opt/geckodriver /opt/geckodriver-"$GK_VERSION" \
+  && chmod 755 /opt/geckodriver-"$GK_VERSION" \
+  && ln -fs /opt/geckodriver-"$GK_VERSION" /usr/bin/geckodriver
 
 # Python 3.5 and Python Pip
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ ENV DISPLAY=:20
 # Essential tools and xvfb
 RUN apt-get update && apt-get install -y \
     software-properties-common \
-    unzip=6.00 \
-    wget=1.21.2 \
-    bzip2=1.0.8 \
+    unzip \
+    wget \
+    bzip2 \
     xvfb \
-    x11vnc=0.9.16 \
-    fluxbox=1.3.5 \
+    x11vnc \
+    fluxbox \
     xterm
 
 # Chrome browser to run the tests
@@ -45,18 +45,18 @@ RUN if [ "${CHROME_DRIVER_VERSION}" != "113.0.5672.63" ]; then \
 #Firefox browser to run the tests
 ARG FIREFOX_VERSION=109.0
 RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-"$FIREFOX_VERSION"-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/"$FIREFOX_VERSION"/linux-x86_64/en-US/firefox-"$FIREFOX_VERSION".tar.bz2"; fi)" \
-  && apt-get update -qqy \
+  apt-get -qqy update \
   && apt-get -qqy --no-install-recommends install firefox \
-  && apt-get install libdbus-glib-1-2 \
+  && apt-get -y install libdbus-glib-1-2 \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 "$FIREFOX_DOWNLOAD_URL" \
   && apt-get -y purge firefox \
   && rm -rf /opt/firefox \
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
+  && mv /opt/firefox /opt/firefox-"$FIREFOX_VERSION" \
   && ln -fs /opt/firefox-"$FIREFOX_VERSION"/firefox /usr/bin/firefox \
-  && apt-get clean \
+  && apt-get -y clean \
   && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,18 +45,18 @@ RUN if [ "${CHROME_DRIVER_VERSION}" != "113.0.5672.63" ]; then \
 #Firefox browser to run the tests
 ARG FIREFOX_VERSION=109.0
 RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-"$FIREFOX_VERSION"-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/"$FIREFOX_VERSION"/linux-x86_64/en-US/firefox-"$FIREFOX_VERSION".tar.bz2"; fi)" \
-  apt-get -qqy update \
+  && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
-  && apt-get -y install libdbus-glib-1-2 \
+  && apt-get install libdbus-glib-1-2 \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 "$FIREFOX_DOWNLOAD_URL" \
   && apt-get -y purge firefox \
   && rm -rf /opt/firefox \
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-"$FIREFOX_VERSION" \
+  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-"$FIREFOX_VERSION"/firefox /usr/bin/firefox \
-  && apt-get -y clean \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,17 @@ RUN apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Creating a new directory
 RUN mkdir /shell_script
+
+# Copying shell script to directory
 COPY entrypoint.sh /shell_script
+
+# Setting the working directory
 WORKDIR /shell_script
 
+# Setting the entry point
 ENTRYPOINT ["/bin/bash", "/shell_script/entrypoint.sh"]
 
+# Setting the default command to be run in the container
 CMD ["sh", "-c", "Xvfb :20 -screen 0 1366x768x16 & x11vnc -passwd password -display :20 -N -forever"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@ RUN apt-get update && apt-get install -y \
     xterm 
 
 # Chrome browser to run the tests
-ARG CHROME_VERSION=113.0.5672.126
+ARG CHROME_VERSION=114.0.5735.106
 RUN wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && apt-key add /tmp/google.pub && rm /tmp/google.pub && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list && mkdir -p /usr/share/desktop-directories && apt-get -y update && apt-get install -y google-chrome-stable=${CHROME_VERSION}-1 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Disable the SUID sandbox so that chrome can launch without being in a privileged container
 RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /opt/google/chrome/google-chrome && printf "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome && chmod 755 /opt/google/chrome/google-chrome
 
 # Chrome Driver
-ARG CHROME_DRIVER_VERSION=113.0.5672.63
+ARG CHROME_DRIVER_VERSION=114.0.5735.90
 RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE')"; else echo "${CHROME_DRIVER_VERSION}"; fi)" \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/"$CD_VERSION"/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
@@ -34,7 +34,7 @@ RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then ech
   && chmod 755 /opt/selenium/chromedriver-"$CD_VERSION" \
   && ln -fs /opt/selenium/chromedriver-"$CD_VERSION" /usr/bin/chromedriver
 
-RUN if [ "${CHROME_DRIVER_VERSION}" != "113.0.5672.63" ]; then \
+RUN if [ "${CHROME_DRIVER_VERSION}" != "114.0.5735.90" ]; then \
   mkdir -p /opt/selenium && \
   wget -qO /opt/selenium/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip && \
   unzip /opt/selenium/chromedriver_linux64.zip -d /opt/selenium && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,19 +45,20 @@ RUN if [ "${CHROME_DRIVER_VERSION}" != "113.0.5672.63" ]; then \
 #Firefox browser to run the tests
 ARG FIREFOX_VERSION=109.0
 RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-"$FIREFOX_VERSION"-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/"$FIREFOX_VERSION"/linux-x86_64/en-US/firefox-"$FIREFOX_VERSION".tar.bz2"; fi)" \
-  && apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install firefox \
-  && apt-get install libdbus-glib-1-2 \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-  && wget --no-verbose -O /tmp/firefox.tar.bz2 "$FIREFOX_DOWNLOAD_URL" \
-  && apt-get -y purge firefox \
-  && rm -rf /opt/firefox \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-  && ln -fs /opt/firefox-"$FIREFOX_VERSION"/firefox /usr/bin/firefox \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+    && echo "Firefox download URL: $FIREFOX_DOWNLOAD_URL" \
+    && apt-get -qqy update \
+    && apt-get -qqy --no-install-recommends install firefox \
+    && apt-get -y install libdbus-glib-1-2 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+    && wget --no-verbose -O /tmp/firefox.tar.bz2 "$FIREFOX_DOWNLOAD_URL" \
+    && apt-get -y purge firefox \
+    && rm -rf /opt/firefox \
+    && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+    && rm /tmp/firefox.tar.bz2 \
+    && mv /opt/firefox /opt/firefox-"$FIREFOX_VERSION" \
+    && ln -fs /opt/firefox-"$FIREFOX_VERSION"/firefox /usr/bin/firefox \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver
 ARG GECKODRIVER_VERSION=0.32.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /o
 # Chrome Driver
 ARG CHROME_DRIVER_VERSION=113.0.5672.63
 RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo "$(wget -qO- 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE')"; else echo "${CHROME_DRIVER_VERSION}"; fi)" \
-  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
+  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/"$CD_VERSION"/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
   && rm /tmp/chromedriver_linux64.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     python3.10 \
-    python3-setuptools \
-    python3-pip \
+    python3-setuptools=59.6.0-1.2ubuntu0.22.04.1 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,28 @@
 FROM ubuntu:22.04
 LABEL maintainer = "Qxf2 Services"
 
+ENV DISPLAY=:20
+
 # Essential tools and xvfb
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     unzip \
     wget \
     bzip2 \
-    xvfb 
-    
+    xvfb \
+    x11vnc \
+    fluxbox \
+    xterm
+
 # Chrome browser to run the tests
-ARG CHROME_VERSION=latest
-RUN if [ ${CHROME_VERSION} = "latest" ]; then wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && apt-key add /tmp/google.pub && rm /tmp/google.pub  && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list  && mkdir -p /usr/share/desktop-directories  && apt-get -y update && apt-get install -y google-chrome-stable; else wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add && wget https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_$CHROME_VERSION.deb && dpkg -i download-chrome*.deb || true && apt-get install -y -f && rm -rf /var/lib/apt/lists/*;fi \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ARG CHROME_VERSION=113.0.5672.92
+RUN wget -qO /tmp/google.pub https://dl-ssl.google.com/linux/linux_signing_key.pub && apt-key add /tmp/google.pub && rm /tmp/google.pub && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list && mkdir -p /usr/share/desktop-directories && apt-get -y update && apt-get install -y google-chrome-stable=${CHROME_VERSION}-1 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Disable the SUID sandbox so that chrome can launch without being in a privileged container
-RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /opt/google/chrome/google-chrome \
-        && printf "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome \
-        && chmod 755 /opt/google/chrome/google-chrome
+RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /opt/google/chrome/google-chrome && printf "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome && chmod 755 /opt/google/chrome/google-chrome
 
 # Chrome Driver
-ARG CHROME_DRIVER_VERSION=latest
+ARG CHROME_DRIVER_VERSION=113.0.5672.63
 RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo "${CHROME_DRIVER_VERSION}"; fi)" \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
@@ -33,19 +34,20 @@ RUN CD_VERSION="$(if [ "${CHROME_DRIVER_VERSION:-latest}" = "latest" ]; then ech
   && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
   && ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
 
-RUN if [ ${CHROME_DRIVER_VERSION} != "latest" ]; then \
+RUN if [ ${CHROME_DRIVER_VERSION} != "113.0.5672.63" ]; then \
   mkdir -p /opt/selenium && \
   wget -qO /opt/selenium/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip && \
   unzip /opt/selenium/chromedriver_linux64.zip -d /opt/selenium && \
   rm -rf /opt/selenium/chromedriver_linux64.zip && \
-  ln -fs /opt/selenium/chromedriver /usr/local/bin/chromedriver; \    
+  ln -fs /opt/selenium/chromedriver /usr/local/bin/chromedriver; \
   fi
 
 #Firefox browser to run the tests
-ARG FIREFOX_VERSION=latest
+ARG FIREFOX_VERSION=109.0
 RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi)" \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
+  && apt-get install libdbus-glib-1-2 \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 $FIREFOX_DOWNLOAD_URL \
   && apt-get -y purge firefox \
@@ -58,7 +60,7 @@ RUN FIREFOX_DOWNLOAD_URL="$(if [ "$FIREFOX_VERSION" = "latest" ]; then echo "htt
   && rm -rf /var/lib/apt/lists/*
 
 #Geckodriver
-ARG GECKODRIVER_VERSION=latest
+ARG GECKODRIVER_VERSION=0.32.2
 RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo "$GECKODRIVER_VERSION"; fi)" \
   && echo "Using GeckoDriver version: "$GK_VERSION \
   && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \
@@ -77,3 +79,11 @@ RUN apt-get install -y --no-install-recommends \
     python3-pip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /shell_script
+COPY entrypoint.sh /shell_script
+WORKDIR /shell_script
+
+ENTRYPOINT ["/bin/bash", "/shell_script/entrypoint.sh"]
+
+CMD ["sh", "-c", "Xvfb :20 -screen 0 1366x768x16 & x11vnc -passwd password -display :20 -N -forever"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     x11vnc \
     fluxbox \
-    xterm
+    xterm 
 
 # Chrome browser to run the tests
 ARG CHROME_VERSION=113.0.5672.92

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,11 @@ RUN GK_VERSION="$(if [ "${GECKODRIVER_VERSION:-latest}" = "latest" ]; then echo 
   && chmod 755 /opt/geckodriver-"$GK_VERSION" \
   && ln -fs /opt/geckodriver-"$GK_VERSION" /usr/bin/geckodriver
 
-# Python 3.10 and Python Pip
-RUN apt-get update && apt-get install -y python3.10 python3-setuptools python3-pip \
+# Python 3.5 and Python Pip
+RUN apt-get update && apt-get install -y \
+    python3.10 \
+    python3-setuptools=59.6.0-1.2ubuntu0.22.04.1 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export DISPLAY=:20
+Xvfb :20 -screen 0 1366x768x16 &
+
+# Start x11vnc
+x11vnc -passwd TestVNC -display :20 -N -forever &
+
+# Run CMD command
+exec "$@"


### PR DESCRIPTION
* Analyzing Dockerfile of POM frame work using Codacy
* After resolving of each issue which is  detected by Codacy, building an image using `docker build --tag image_name .` command and running container using `docker run -d -it <image_id>` 
* While running container copying the test folder from local to container using `docker cp <path_of_local_folder> <container_id>:<path_of_directory_in_container>`
* Running selenium tests against Chrome and Firefox drivers

* Issues detected by Codacy are as follows:
*  Always tag the version of an image explicitly 
Instead of using `FROM ubuntu` , we should use `FROM ubuntu:22.04` to explicitly specify the Ubuntu version that we want to use. This will ensure that the image always uses the same version of Ubuntu, even if the ubuntu image is updated in the future.

* Delete the apt-get lists after installing something
Using `&& apt-get clean \` `&& rm -rf /var/lib/apt/lists/* `the apt-get lists should be deleted after installing packages using the apt-get install command in a Dockerfile to free up space in the Docker image.

* Avoid additional packages by specifying `--no-install-recommends`
Adding `--no-install-recommends` flag to the `apt-get install` command to prevent `apt-get` from installing recommended packages, reducing the size of the Docker image.

* Double quote to prevent globbing and word splitting
By adding double quotes, the shell will treat the entire command as a single argument and prevent any unexpected behavior caused by globbing or word splitting. 

* `echo` may not expand escape sequences. Use` printf`
Using the `printf` command instead of `echo` , which allows for better control over the formatting and expansion of escape sequences.

* Use 'cd ... || exit' or 'cd ... || return' in case cd fails
Use of `cd ... || exit or cd ... || return` in script to exit with an error code if the cd command fails

* Useless `cat.` Consider `'cmd < file | ..' or 'cmd file | ..'` instead.
Use of `cat` is unnecessary because the output of `wget` can be directly piped to `apt-key add` without the need to store it in a file and then use `cat` to pass it to` apt-key add`

* Pin versions in `apt get install.` Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
When installing packages with `apt-get install,` we have to pin the versions of the packages to avoid any unintended upgrades or compatibility issues with the software being installed

* To enable display graphical user interfaces, combining commands within the Dockerfile itself `export DISPLAY=:20` `Xvfb :20 -screen 0 1366x768x16 &` 