### PR TITLE
Fix log obj issue

### DIFF
--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -171,9 +171,7 @@ class Base_Page(Borg,unittest.TestCase):
             if not os.path.exists(self.logs_parent_dir):
                 os.makedirs(self.logs_parent_dir)
         except Exception as e:
-            # self.write("Exception when trying to set directory structure")
-            # self.write(str(e))
-            # self.exceptions.append("Error when setting up the directory structure")
+            # Using print as log_obj wouldnt be created to write this exception to log file
             print("Exception when trying to set screenshot directory due to error:",str(e))
 
 

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -171,9 +171,10 @@ class Base_Page(Borg,unittest.TestCase):
             if not os.path.exists(self.logs_parent_dir):
                 os.makedirs(self.logs_parent_dir)
         except Exception as e:
-            self.write("Exception when trying to set directory structure")
-            self.write(str(e))
-            self.exceptions.append("Error when setting up the directory structure")
+            # self.write("Exception when trying to set directory structure")
+            # self.write(str(e))
+            # self.exceptions.append("Error when setting up the directory structure")
+            print("Exception when trying to set screenshot directory due to error:",str(e))
 
 
     def set_screenshot_dir(self,os_name,os_version,browser,browser_version):

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -276,7 +276,7 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
     def print_exception(exception, remote_flag):
         """Print out the exception message and suggest the solution based on the remote flag."""
         if remote_flag.lower() == 'y':
-            solution = "It looks like you are trying to use a cloud service provider(BrowserStack or Sauce Labs) to run your test. \nPlease make sure you have updated ./conf/remote_credentials.py with the right credentials and also check the BS upload url and try again. \nTo use your local browser please run the test with the -M N flag"
+            solution = "It looks like you are trying to use a cloud service provider(BrowserStack or Sauce Labs) to run your test. \nPlease make sure you have updated ./conf/remote_credentials.py with the right credentials and also check for BrowserStack upload url changes and try again. \nTo use your local browser please run the test with the -M N flag"
         else:
             solution = "It looks like you are trying to run test cases with Local Appium Setup. \nPlease make sure to run Appium Server and try again."
 

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -276,7 +276,7 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
     def print_exception(exception, remote_flag):
         """Print out the exception message and suggest the solution based on the remote flag."""
         if remote_flag.lower() == 'y':
-            solution = "It looks like you are trying to use a cloud service provider(BrowserStack or Sauce Labs) to run your test. \nPlease make sure you have updated ./conf/remote_credentials.py with the right credentials and try again. \nTo use your local browser please run the test with the -M N flag"
+            solution = "It looks like you are trying to use a cloud service provider(BrowserStack or Sauce Labs) to run your test. \nPlease make sure you have updated ./conf/remote_credentials.py with the right credentials and also check the BS upload url and try again. \nTo use your local browser please run the test with the -M N flag"
         else:
             solution = "It looks like you are trying to run test cases with Local Appium Setup. \nPlease make sure to run Appium Server and try again."
 

--- a/page_objects/drivers/remote_options.py
+++ b/page_objects/drivers/remote_options.py
@@ -127,7 +127,7 @@ class RemoteOptions():
             #Upload the apk
             apk_file = os.path.join(app_path, app_name)
             files = {'file': open(apk_file, 'rb')}
-            post_response = requests.post("https://api.browserstack.com/app-automate/upload",
+            post_response = requests.post("https://api-cloud.browserstack.com/app-automate/upload",
                                           files=files, auth=(username, access_key))
             post_json_data = json.loads(post_response.text)
             #Get the app url of the newly uploaded apk


### PR DESCRIPTION
* Removed write method to write exception and used print instead as log_obj wouldn't be created to write this exception to log file set_directory_structure() method 
* Also updated BrowserStack upload url in page_objects/drivers/remote_options.py as its updated
* Circle Ci tests are passing now
https://app.circleci.com/pipelines/github/qxf2/qxf2-page-object-model/463/workflows/52ecebde-f8cd-4b09-9c61-7ed35ea58c86