### PR TITLE
Pytest fix after cleanup

### DIFF
--- a/conf/api_example_conf.py
+++ b/conf/api_example_conf.py
@@ -1,6 +1,3 @@
-#Conf for api example
-api_url="http://127.0.0.1:5000"
-
 #add_car
 car_details = {'name':'figo','brand':'ford','price_range':'5-8 lacs','car_type':'hatchback'}
 

--- a/conf/base_url_conf.py
+++ b/conf/base_url_conf.py
@@ -2,5 +2,5 @@
 Conf file for base_url
 """
 base_url = "https://qxf2.com/"
-api_base_url= " http://35.167.62.251/"
+api_base_url= "http://127.0.0.1:5000"
 

--- a/conf/base_url_conf.py
+++ b/conf/base_url_conf.py
@@ -2,4 +2,5 @@
 Conf file for base_url
 """
 base_url = "https://qxf2.com/"
+api_base_url= "https://35.167.62.251/"
 

--- a/conf/base_url_conf.py
+++ b/conf/base_url_conf.py
@@ -1,6 +1,6 @@
 """
 Conf file for base_url
 """
-base_url = "https://qxf2.com/"
+ui_base_url = "https://qxf2.com/"
 api_base_url= "http://127.0.0.1:5000"
 

--- a/conf/base_url_conf.py
+++ b/conf/base_url_conf.py
@@ -2,5 +2,5 @@
 Conf file for base_url
 """
 base_url = "https://qxf2.com/"
-api_base_url= "https://35.167.62.251/"
+api_base_url= " http://35.167.62.251/"
 

--- a/conftest.py
+++ b/conftest.py
@@ -491,7 +491,7 @@ def pytest_addoption(parser):
                             help="Browser. Valid options are firefox, ie and chrome")
         parser.addoption("--app_url",
                             dest="url",
-                            default=base_url_conf.base_url,
+                            default=base_url_conf.ui_base_url,
                             help="The url of the application")
         parser.addoption("--api_url",
                             dest="url",

--- a/conftest.py
+++ b/conftest.py
@@ -495,7 +495,7 @@ def pytest_addoption(parser):
                             help="The url of the application")
         parser.addoption("--api_url",
                             dest="url",
-                            default="http://35.167.62.251",
+                            default="https://cars-app.qxf2.com/",
                             help="The url of the api")
         parser.addoption("--testrail_flag",
                             dest="testrail_flag",

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from page_objects.PageFactory import PageFactory
 from conf import browser_os_name_conf
 from conf import base_url_conf
-from conf import api_example_conf
 from conf import report_portal_conf
 from utils import post_test_reports_to_slack
 from utils.email_pytest_report import Email_Pytest_Report
@@ -88,7 +87,7 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
         print("Python says:%s"%str(e))
 
 @pytest.fixture
-def test_api_obj(interactivemode_flag,api_url=api_example_conf.api_url):
+def test_api_obj(interactivemode_flag,api_url=base_url_conf.api_base_url):
     "Return an instance of Base Page that knows about the third party integrations"
     try:
         if interactivemode_flag.lower()=='y':

--- a/endpoints/API_Interface.py
+++ b/endpoints/API_Interface.py
@@ -1,14 +1,12 @@
-"""
-A composed interface for all the API objects
-Use the API_Player to talk to this class
-"""
 import requests
 from .Base_API import Base_API
-from .Cars_API_Endpoints import Cars_API_Endpoints
-from .Registration_API_Endpoints import Registration_API_Endpoints
-from .User_API_Endpoints import User_API_Endpoints
 
-class API_Interface(Base_API,Cars_API_Endpoints,Registration_API_Endpoints,User_API_Endpoints):
+try:
+    from .Cars_API_Endpoints import Cars_API_Endpoints
+except ImportError:
+    Cars_API_Endpoints = object
+
+class API_Interface(Base_API,Cars_API_Endpoints):
 	"A composed interface for the API objects"
 
 	def __init__(self, url, session_flag=False):

--- a/endpoints/API_Interface.py
+++ b/endpoints/API_Interface.py
@@ -27,18 +27,18 @@ except ImportError:
     pass
 
 class API_Interface(*base_classes):
-	"A composed interface for the API objects"
+    "A composed interface for the API objects"
 
-	def __init__(self, url, session_flag=False):
-		"Constructor"
-		# make base_url available to all API endpoints
-		self.request_obj = requests
-		if session_flag:
-			self.create_session()
-		self.base_url = url
+    def __init__(self, url, session_flag=False):
+        "Constructor"
+        # make base_url available to all API endpoints
+        self.request_obj = requests
+        if session_flag:
+            self.create_session()
+        self.base_url = url
 
-	def create_session(self):
-		"Create a session object"
-		self.request_obj = requests.Session()
+    def create_session(self):
+        "Create a session object"
+        self.request_obj = requests.Session()
 
-		return self.request_obj
+        return self.request_obj

--- a/endpoints/API_Interface.py
+++ b/endpoints/API_Interface.py
@@ -6,12 +6,27 @@ Use the API_Player to talk to this class
 import requests
 from .Base_API import Base_API
 
+base_classes = [Base_API]
+
 try:
     from .Cars_API_Endpoints import Cars_API_Endpoints
+    base_classes.append(Cars_API_Endpoints)
 except ImportError:
-    Cars_API_Endpoints = object
+    pass
 
-class API_Interface(Base_API,Cars_API_Endpoints):
+try:
+    from .Registration_API_Endpoints import Registration_API_Endpoints
+    base_classes.append(Registration_API_Endpoints)
+except ImportError:
+    pass
+
+try:
+    from .User_API_Endpoints import User_API_Endpoints
+    base_classes.append(User_API_Endpoints)
+except ImportError:
+    pass
+
+class API_Interface(*base_classes):
 	"A composed interface for the API objects"
 
 	def __init__(self, url, session_flag=False):

--- a/endpoints/API_Interface.py
+++ b/endpoints/API_Interface.py
@@ -1,3 +1,8 @@
+"""
+A composed interface for all the API objects
+Use the API_Player to talk to this class
+"""
+
 import requests
 from .Base_API import Base_API
 

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -9,7 +9,7 @@ from .API_Interface import API_Interface
 from utils.results import Results
 import urllib.parse
 import logging
-from conf import api_example_conf as conf
+
 
 
 class API_Player(Results):
@@ -88,6 +88,7 @@ class API_Player(Results):
 
     def register_car(self, car_name, brand, auth_details=None):
         "register car"
+        from conf import api_example_conf as conf
         url_params = {'car_name': car_name, 'brand': brand}
         url_params_encoded = urllib.parse.urlencode(url_params)
         customer_details = conf.customer_details

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -10,8 +10,6 @@ from utils.results import Results
 import urllib.parse
 import logging
 
-
-
 class API_Player(Results):
     "The class that maintains the test context/state"
 
@@ -88,6 +86,7 @@ class API_Player(Results):
 
     def register_car(self, car_name, brand, auth_details=None):
         "register car"
+        # pylint: disable=import-outside-toplevel
         from conf import api_example_conf as conf
         url_params = {'car_name': car_name, 'brand': brand}
         url_params_encoded = urllib.parse.urlencode(url_params)

--- a/endpoints/Cars_API_Endpoints.py
+++ b/endpoints/Cars_API_Endpoints.py
@@ -1,8 +1,10 @@
 """
 API endpoints for Cars
 """
+from .Registration_API_Endpoints import Registration_API_Endpoints
+from .User_API_Endpoints import User_API_Endpoints
 
-class Cars_API_Endpoints:
+class Cars_API_Endpoints(Registration_API_Endpoints, User_API_Endpoints):
 	"Class for cars endpoints"
 
 	def cars_url(self,suffix=''):

--- a/endpoints/Cars_API_Endpoints.py
+++ b/endpoints/Cars_API_Endpoints.py
@@ -1,7 +1,7 @@
 """
 API endpoints for Cars
 """
-class Cars_API_Endpoints():
+class Cars_API_Endpoints:
 	"Class for cars endpoints"
 
 	def cars_url(self,suffix=''):

--- a/endpoints/Cars_API_Endpoints.py
+++ b/endpoints/Cars_API_Endpoints.py
@@ -1,10 +1,7 @@
 """
 API endpoints for Cars
 """
-from .Registration_API_Endpoints import Registration_API_Endpoints
-from .User_API_Endpoints import User_API_Endpoints
-
-class Cars_API_Endpoints(Registration_API_Endpoints, User_API_Endpoints):
+class Cars_API_Endpoints():
 	"Class for cars endpoints"
 
 	def cars_url(self,suffix=''):

--- a/page_objects/PageFactory.py
+++ b/page_objects/PageFactory.py
@@ -9,12 +9,12 @@ Pages implemented so far:
 4. Bitcoin main page
 5. Bitcoin price page
 """
-import conf.base_url_conf
+from conf import base_url_conf as url_conf
 
 class PageFactory():
     "PageFactory uses the factory design pattern."
     @staticmethod
-    def get_page_object(page_name,base_url=conf.base_url_conf.base_url):
+    def get_page_object(page_name,base_url=url_conf.ui_base_url):
         "Return the appropriate page object based on page_name"
         test_obj = None
         page_name = page_name.lower()

--- a/page_objects/PageFactory.py
+++ b/page_objects/PageFactory.py
@@ -9,6 +9,7 @@ Pages implemented so far:
 4. Bitcoin main page
 5. Bitcoin price page
 """
+# pylint: disable=import-outside-toplevel, E0401
 from conf import base_url_conf as url_conf
 
 class PageFactory():

--- a/page_objects/PageFactory.py
+++ b/page_objects/PageFactory.py
@@ -9,16 +9,7 @@ Pages implemented so far:
 4. Bitcoin main page
 5. Bitcoin price page
 """
-
-from page_objects.zero_mobile_page import Zero_Mobile_Page
-from page_objects.zero_page import Zero_Page
-from page_objects.tutorial_main_page import Tutorial_Main_Page
-from page_objects.tutorial_redirect_page import Tutorial_Redirect_Page
-from page_objects.contact_page import Contact_Page
-from page_objects.bitcoin_price_page import Bitcoin_Price_Page
-from page_objects.bitcoin_main_page import Bitcoin_Main_Page
 import conf.base_url_conf
-
 
 class PageFactory():
     "PageFactory uses the factory design pattern."
@@ -28,18 +19,25 @@ class PageFactory():
         test_obj = None
         page_name = page_name.lower()
         if page_name in ["zero","zero page","agent zero"]:
+            from page_objects.zero_page import Zero_Page
             test_obj = Zero_Page(base_url=base_url)
         elif page_name in ["zero mobile","zero mobile page"]:
+            from page_objects.zero_mobile_page import Zero_Mobile_Page
             test_obj = Zero_Mobile_Page()
         elif page_name == "main page":
+            from page_objects.tutorial_main_page import Tutorial_Main_Page
             test_obj = Tutorial_Main_Page(base_url=base_url)
         elif page_name == "redirect":
+            from page_objects.tutorial_redirect_page import Tutorial_Redirect_Page
             test_obj = Tutorial_Redirect_Page(base_url=base_url)
         elif page_name == "contact page":
+            from page_objects.contact_page import Contact_Page
             test_obj = Contact_Page(base_url=base_url)
         elif page_name == "bitcoin main page":
+            from page_objects.bitcoin_main_page import Bitcoin_Main_Page
             test_obj = Bitcoin_Main_Page()
         elif page_name == "bitcoin price page":
+            from page_objects.bitcoin_price_page import Bitcoin_Price_Page
             test_obj = Bitcoin_Price_Page()
             #"New pages added needs to be updated in the get_all_page_names method too"
         return test_obj

--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -18,6 +18,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from endpoints.API_Player import API_Player
 from conf import api_example_conf as conf
+from conf import base_url_conf
 from conftest import interactivemode_flag
 
 @pytest.mark.API
@@ -141,8 +142,8 @@ def test_api_example(test_api_obj):
 
     except Exception as e:
         print(e)
-        if conf.api_url == 'http://127.0.0.1:5000':
-            test_api_obj.write("Please run the test against http://35.167.62.251/ by changing the api_url in api_example_conf.py")
+        if base_url_conf.api_base_url == 'http://127.0.0.1:5000':
+            test_api_obj.write("Please run the test against http://35.167.62.251/ by changing the api_base_url in base_url_conf.py")
             test_api_obj.write("OR")
             test_api_obj.write("Clone the repo 'https://github.com/qxf2/cars-api.git' and run the cars_app inorder to run the test against your system")
 

--- a/tests/test_api_example.py
+++ b/tests/test_api_example.py
@@ -143,7 +143,7 @@ def test_api_example(test_api_obj):
     except Exception as e:
         print(e)
         if base_url_conf.api_base_url == 'http://127.0.0.1:5000':
-            test_api_obj.write("Please run the test against http://35.167.62.251/ by changing the api_base_url in base_url_conf.py")
+            test_api_obj.write("Please run the test against https://cars-app.qxf2.com/ by changing the api_base_url in base_url_conf.py")
             test_api_obj.write("OR")
             test_api_obj.write("Clone the repo 'https://github.com/qxf2/cars-api.git' and run the cars_app inorder to run the test against your system")
 

--- a/tests/test_boilerplate.py
+++ b/tests/test_boilerplate.py
@@ -17,7 +17,7 @@ def test_boilerplate(test_obj):
         actual_pass = -1
 
         #This is the test object, you can change it to the desired page with relevance to the page factory
-        test_obj = PageFactory.get_page_object("main page", base_url=test_obj.base_url)
+        test_obj = PageFactory.get_page_object("zero", base_url=test_obj.base_url)
 
         #Print out the result
         test_obj.write_test_summary()

--- a/utils/Option_Parser.py
+++ b/utils/Option_Parser.py
@@ -26,7 +26,7 @@ class Option_Parser:
                             help="The url of the application")
         self.parser.add_option("-A","--api_url",
                             dest="api_url",
-                            default="http://35.167.62.251/",
+                            default="https://cars-app.qxf2.com/",
                             help="The url of the api")
         self.parser.add_option("-X","--testrail_flag",
                             dest="testrail_flag",

--- a/utils/Option_Parser.py
+++ b/utils/Option_Parser.py
@@ -22,7 +22,7 @@ class Option_Parser:
                             help="Browser. Valid options are firefox, ie and chrome")
         self.parser.add_option("-U","--app_url",
                             dest="url",
-                            default=conf.base_url,
+                            default=conf.ui_base_url,
                             help="The url of the application")
         self.parser.add_option("-A","--api_url",
                             dest="api_url",

--- a/utils/interactive_mode.py
+++ b/utils/interactive_mode.py
@@ -585,7 +585,7 @@ def get_api_url():
     "Get the API URL"
     api_url = questionary.select("Select the API url",
                                   choices=["localhost",
-                                  "http://35.167.62.251/",
+                                  "https://cars-app.qxf2.com/",
                                   "Enter the URL manually"]).ask()
     if api_url == "localhost":
         api_url = base_url_conf.api_base_url

--- a/utils/interactive_mode.py
+++ b/utils/interactive_mode.py
@@ -4,7 +4,7 @@ Implementing the questionaty library to fetch the users choices for different ar
 import sys
 import questionary
 from clear_screen import clear
-from conf import api_example_conf
+from conf import base_url_conf
 from conf import browser_os_name_conf as conf
 from conf import remote_credentials
 
@@ -242,7 +242,7 @@ def ask_questions_api(api_url,session_flag=True):
             api_url = get_api_url()
 
         if response == "Reset back to default settings":
-            api_url = api_example_conf.api_url
+            api_url = base_url_conf.api_base_url
             session_flag = True
             questionary.print("Reverted back to default settings",
                                style="bold fg:green")
@@ -588,7 +588,7 @@ def get_api_url():
                                   "http://35.167.62.251/",
                                   "Enter the URL manually"]).ask()
     if api_url == "localhost":
-        api_url = api_example_conf.api_url
+        api_url = base_url_conf.api_base_url
     if api_url == "Enter the URL manually":
         api_url = questionary.text("Enter the url").ask()
 


### PR DESCRIPTION
In this PR, I have fixed the POM framework wherein it used to fail after the repo cleanup. 
I have made the following changes to the framework:
- Adding conditional imports to `API_Interface` and` PageFactory`
- Moving the `api_base_url` to `base_url_conf`
- Removing references to deleted classes in boilerplate test
- Modified `test_api_example` and other classes to use `api_url` from `base_url_conf` rather than `api_base_url`

To test the changes:
1. Run the tests 'test_api_example.py' and 'test_example_form.py' to make sure both UI and API tests are working fine.
2. Run the utility script 'utils/clean_up_repo.py'
3. Run the test 'test_boilerplate.py'
4. It should execute without any issues. 