### PR TITLE
Fix tests for latest Selenium and Appium versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   toxify:
 
       docker:
-        - image: themattrix/tox
+        - image: 31z4/tox
 
       parallelism: 3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   toxify:
 
       docker:
-        - image: 31z4/tox
+        - image: divio/multi-python
 
       parallelism: 3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,9 @@ jobs:
         - run:
             name: Run different Tox environments on different Containers
             command: |
-               if [ $CIRCLE_NODE_INDEX == "0" ] ; then tox -e py37 ; fi
-               if [ $CIRCLE_NODE_INDEX == "1" ] ; then tox -e py38 ; fi
+               if [ $CIRCLE_NODE_INDEX == "0" ] ; then tox -e py39 ; fi
+               if [ $CIRCLE_NODE_INDEX == "1" ] ; then tox -e py310 ; fi
+               if [ $CIRCLE_NODE_INDEX == "2" ] ; then tox -e py311 ; fi
 
         - store_artifacts:
             path: ./screenshots

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -121,7 +121,7 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
         options = self.get_browser(browser, browser_version)
 
         #set saucelab platform
-        options = self.saucelab_platform(options, os_name, os_version) 
+        options = self.saucelab_platform(options, os_name, os_version)
         sauce_options = {}
         sauce_options = self.saucelab_credentials(sauce_options, username, password)
         options.set_capability('sauce:options', sauce_options)
@@ -290,8 +290,8 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
         bstack_mobile_options['sessionName'] = 'Appium Python Test'
         bstack_mobile_options['appiumVersion'] = appium_version
         bstack_mobile_options['realMobile'] = 'true'
-        bstack_mobile_options["networkProfile"] : "4g-lte-good"
-        bstack_mobile_options = self.browserstack_credentials(bstack_mobile_options,username, password)    
+        bstack_mobile_options["networkProfile"] = "4g-lte-good"
+        bstack_mobile_options = self.browserstack_credentials(bstack_mobile_options, username, password)
         desired_capabilities['app'] = self.browser_stack_upload(app_name, app_path) #upload the application to the Browserstack Storage
         desired_capabilities['bstack:options'] = bstack_mobile_options
 

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -5,7 +5,8 @@ This module gets the webdrivers for different browsers and sets up the remote te
 import os
 import sys
 from selenium import webdriver
-from selenium.webdriver.remote.webdriver import RemoteConnection
+#from selenium.webdriver.remote.webdriver import RemoteConnection
+from selenium.webdriver.remote.remote_connection import RemoteConnection
 from appium import webdriver as mobile_webdriver
 from appium.options.android import UiAutomator2Options
 from conf import remote_credentials
@@ -102,7 +103,7 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
 
         desired_capabilities['browserstack.debug'] = str(screenshot_conf.BS_ENABLE_SCREENSHOTS).lower()
 
-        web_driver = webdriver.Remote(RemoteConnection("http://%s:%s@hub-cloud.browserstack.com/wd/hub"
+        web_driver = webdriver.Remote(command_executor=RemoteConnection("http://%s:%s@hub-cloud.browserstack.com/wd/hub"
                                                        %(username, password), resolve_ip=False), desired_capabilities=desired_capabilities)
 
         return web_driver

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -7,13 +7,14 @@ import sys
 from selenium import webdriver
 from selenium.webdriver.remote.webdriver import RemoteConnection
 from appium import webdriver as mobile_webdriver
+from appium.options.android import UiAutomator2Options
 from conf import remote_credentials
 from page_objects.drivers.remote_options import RemoteOptions
 from page_objects.drivers.local_browsers import LocalBrowsers
 from conf import ports_conf
 from conf import screenshot_conf
 
-localhost_url = 'http://localhost:%s/wd/hub'%ports_conf.port #Set the url of localhost
+localhost_url = 'http://localhost:%s'%ports_conf.port #Set the url of localhost
 
 class DriverFactory(RemoteOptions, LocalBrowsers):
     """Class contains methods for getting web drivers and setting up remote testing platforms."""
@@ -183,15 +184,21 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
                 desired_capabilities['appPackage'] = app_package
                 desired_capabilities['appActivity'] = app_activity
                 if device_flag.lower() == 'y':
-                    mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
+                    mobile_driver = self.set_capabilities_options(desired_capabilities)
+                    #mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
                 else:
                     desired_capabilities['app'] = os.path.join(app_path, app_name)
-                    mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
+                    mobile_driver = self.set_capabilities_options(desired_capabilities)
+                    #mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
             except Exception as exception:
                 self.print_exception(exception, remote_flag)
 
         return mobile_driver
 
+    def set_capabilities_options(self, desired_capabilities):
+        capabilities_options = UiAutomator2Options().load_capabilities(desired_capabilities)
+        mobile_driver = mobile_webdriver.Remote(command_executor=localhost_url,options=capabilities_options)
+        return mobile_driver
 
     def ios(self, remote_flag, desired_capabilities, app_path, app_name, username,
             password, app_package, no_reset_flag, ud_id, org_id, signing_id,
@@ -214,8 +221,8 @@ class DriverFactory(RemoteOptions, LocalBrowsers):
                     desired_capabilities['xcodeOrgId'] = org_id
                     desired_capabilities['xcodeSigningId'] = signing_id
 
-                mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
-
+                mobile_driver = self.set_capabilities_options(desired_capabilities)
+                #mobile_driver = mobile_webdriver.Remote(localhost_url, desired_capabilities)
             except Exception as exception:
                 self.print_exception(exception, remote_flag)
 

--- a/page_objects/drivers/remote_options.py
+++ b/page_objects/drivers/remote_options.py
@@ -5,7 +5,6 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.ie.options import Options as IeOptions
 from selenium.webdriver.chrome.options import Options as ChromeOptions
-#from selenium.webdriver.opera.options import Options as OperaOptions
 from selenium.webdriver.safari.options import Options as SafariOptions
 from conf import remote_credentials
 import os
@@ -38,14 +37,6 @@ class RemoteOptions():
         options.browser_version = browser_version
 
         return options
-
-    @staticmethod
-    def opera(browser_version):
-        """Set web_browser as Opera."""
-        desired_capabilities = DesiredCapabilities.OPERA
-        desired_capabilities['browser_version'] = browser_version
-
-        return desired_capabilities
 
     @staticmethod
     def safari(browser_version):

--- a/page_objects/drivers/remote_options.py
+++ b/page_objects/drivers/remote_options.py
@@ -21,18 +21,11 @@ class RemoteOptions():
         """Set web browser as firefox."""
         options = FirefoxOptions()
         options.browser_version = browser_version
-
-        desired_capabilities = DesiredCapabilities.FIREFOX
-        desired_capabilities['browser_version'] = browser_version
-
         return options
 
     @staticmethod
     def explorer(browser_version):
         """Set web browser as Explorer."""
-        desired_capabilities = DesiredCapabilities.INTERNETEXPLORER
-        desired_capabilities['browser_version'] = browser_version
-
         options = IeOptions()
         options.browser_version = browser_version
 
@@ -41,9 +34,6 @@ class RemoteOptions():
     @staticmethod
     def chrome(browser_version):
         """Set web browser as Chrome."""
-        desired_capabilities = DesiredCapabilities.CHROME
-        desired_capabilities['browser_version'] = browser_version
-
         options = ChromeOptions()
         options.browser_version = browser_version
 
@@ -60,9 +50,6 @@ class RemoteOptions():
     @staticmethod
     def safari(browser_version):
         """Set web browser as Safari."""
-        desired_capabilities = DesiredCapabilities.SAFARI
-        desired_capabilities['browser_version'] = browser_version
-
         options = SafariOptions()
         options.browser_version = browser_version
 
@@ -70,8 +57,7 @@ class RemoteOptions():
 
     @staticmethod
     def set_os(desired_capabilities, os_name, os_version):
-        """Set os name and os_version."""
-        
+        """Set os name and os_version."""      
         desired_capabilities['os'] = os_name
         desired_capabilities['osVersion'] = os_version
 
@@ -92,11 +78,10 @@ class RemoteOptions():
         return desired_capabilities
 
     @staticmethod
-    def saucelab_platform(desired_capabilities, os_name, os_version):
+    def saucelab_platform(options, os_name, os_version):
         """Set platform for saucelab."""
-        desired_capabilities['platform_name'] = os_name + ' '+os_version
-
-        return desired_capabilities
+        options.platform_name = os_name + ' '+os_version
+        return options
 
     @staticmethod
     def set_mobile_device(mobile_os_name, mobile_os_version, device_name):

--- a/page_objects/drivers/remote_options.py
+++ b/page_objects/drivers/remote_options.py
@@ -2,6 +2,11 @@
 Set the desired option for running the test on a remote platform.
 """
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.ie.options import Options as IeOptions
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+#from selenium.webdriver.opera.options import Options as OperaOptions
+from selenium.webdriver.safari.options import Options as SafariOptions
 from conf import remote_credentials
 import os
 import requests
@@ -14,10 +19,13 @@ class RemoteOptions():
     @staticmethod
     def firefox(browser_version):
         """Set web browser as firefox."""
+        options = FirefoxOptions()
+        options.browser_version = browser_version
+
         desired_capabilities = DesiredCapabilities.FIREFOX
         desired_capabilities['browser_version'] = browser_version
 
-        return desired_capabilities
+        return options
 
     @staticmethod
     def explorer(browser_version):
@@ -25,7 +33,10 @@ class RemoteOptions():
         desired_capabilities = DesiredCapabilities.INTERNETEXPLORER
         desired_capabilities['browser_version'] = browser_version
 
-        return desired_capabilities
+        options = IeOptions()
+        options.browser_version = browser_version
+
+        return options
 
     @staticmethod
     def chrome(browser_version):
@@ -33,7 +44,10 @@ class RemoteOptions():
         desired_capabilities = DesiredCapabilities.CHROME
         desired_capabilities['browser_version'] = browser_version
 
-        return desired_capabilities
+        options = ChromeOptions()
+        options.browser_version = browser_version
+
+        return options
 
     @staticmethod
     def opera(browser_version):
@@ -49,34 +63,38 @@ class RemoteOptions():
         desired_capabilities = DesiredCapabilities.SAFARI
         desired_capabilities['browser_version'] = browser_version
 
-        return desired_capabilities
+        options = SafariOptions()
+        options.browser_version = browser_version
+
+        return options
 
     @staticmethod
     def set_os(desired_capabilities, os_name, os_version):
         """Set os name and os_version."""
+        
         desired_capabilities['os'] = os_name
-        desired_capabilities['os_version'] = os_version
+        desired_capabilities['osVersion'] = os_version
 
         return desired_capabilities
 
     @staticmethod
     def remote_project_name(desired_capabilities, remote_project_name):
         """Set remote project name for browserstack."""
-        desired_capabilities['project'] = remote_project_name
+        desired_capabilities['projectName'] = remote_project_name
 
         return desired_capabilities
 
     @staticmethod
     def remote_build_name(desired_capabilities, remote_build_name):
         """Set remote build name for browserstack."""
-        desired_capabilities['build'] = remote_build_name+"_"+str(datetime.now().strftime("%c"))
+        desired_capabilities['buildName'] = remote_build_name+"_"+str(datetime.now().strftime("%c"))
 
         return desired_capabilities
 
     @staticmethod
     def saucelab_platform(desired_capabilities, os_name, os_version):
         """Set platform for saucelab."""
-        desired_capabilities['platform'] = os_name + ' '+os_version
+        desired_capabilities['platform_name'] = os_name + ' '+os_version
 
         return desired_capabilities
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests==2.31.0
 reportportal-client==5.0.10
 pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
-selenium==3.13.0
+selenium>=4.12.0
 python_dotenv==0.16.0
 Appium_Python_Client==3.2.0
 pytest-xdist>=1.31
@@ -10,7 +10,8 @@ pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1
 pytest_reportportal==5.0.8
 pillow>=6.2.0
-tesults
+tesults==1.2.1
+boto3==1.34.49
 loguru
 imageio
 questionary>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium>=4.12.0
 python_dotenv==0.16.0
-Appium_Python_Client==3.2.0
+Appium_Python_Client==3.1.1
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1
 pytest_reportportal==5.0.8
 pillow>=6.2.0
 tesults==1.2.1
-boto3==1.34.49
+boto3==1.33.0
 loguru
 imageio
 questionary>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium==3.13.0
 python_dotenv==0.16.0
-Appium_Python_Client==0.28
+Appium_Python_Client
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium==3.13.0
 python_dotenv==0.16.0
-Appium-Python-Client
+Appium-Python-Client==3.2.0
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium==3.13.0
 python_dotenv==0.16.0
-Appium-Python-Client==3.2.0
+Appium_Python_Client==3.2.0
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ requests==2.31.0
 reportportal-client==5.0.10
 pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
-selenium>=4.12.0
+selenium==4.12.0
 python_dotenv==0.16.0
-Appium_Python_Client==3.1.1
+Appium_Python_Client==3.2.0
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium==3.13.0
 python_dotenv==0.16.0
-Appium_Python_Client
+Appium-Python-Client
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1


### PR DESCRIPTION
Have updated mobile tests to run with latest Appium Python Client.

To tests:
- Update your virtual environment with the latest appium python client
- Setup Android Studio and Appium on your local machine
- Download the Bitcoin application
- Run the mobile test on your local machine using command `python -m pytest tests/test_mobile_bitcoin_price.py  --mobile_os_name Android --mobile_os_version 11 --device_name emulator-5554 --app_name Bitcoin.apk  --app_path /d/android_studio/`
- Run mobile test on Remote platform after updating remote credentials, using command  `python -m pytest tests/test_mobile_bitcoin_price.py --app_path=./ --app_name Bitcoin.apk --remote_flag Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial`
- Run selenium tests on remote platform using command `python -m pytest tests/test_example_form.py --app_path=./ --app_name Bitcoin.apk --remote_flag Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial `

