### PR TITLE
Updating the appium download link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ __Optional steps__ for integrating with third-party tools:
 __3. Setup for Mobile/Appium automation__
 
 
-a) [Download and Install appium desktop app](https://github.com/appium/appium-desktop/releases/latest)
+a) [Install appium globally using npm](https://appium.io/docs/en/latest/quickstart/install/)
 
 b) [Download and Install Android Studio and create an emulator](https://developer.android.com/studio/index.html)
 


### PR DESCRIPTION
Appium Desktop is no longer supported. Updated the link to install Appium globally using npm (https://appium.io/docs/en/latest/quickstart/install/)