### PR TITLE
Fix CircleCI failure

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -418,7 +418,7 @@ def pytest_configure(config):
     if_reportportal =config.getoption('--reportportal')
 
     try:
-        config._inicache["rp_uuid"] = os.getenv('report_portal_uuid')
+        config._inicache["rp_api_key"] = os.getenv('report_portal_api_key')
         config._inicache["rp_endpoint"]= os.getenv('report_portal_endpoint')
         config._inicache["rp_project"]=os.getenv('report_portal_project')
         config._inicache["rp_launch"]=os.getenv('report_portal_launch')

--- a/env_conf
+++ b/env_conf
@@ -27,7 +27,7 @@ targets = ['asd@xyz.com','qwe@xyz.com'] # Add recipients email address in a list
 
 
 #REPORT PORTAL
-report_portal_uuid = "Enter your UUID here"
+report_portal_api_key = "Enter your report portal api key here"
 report_portal_endpoint = "Enter your endpoint here"
 report_portal_project = "Enter your Project here"
 report_portal_launch = "Enter your project launch here"

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -223,7 +223,10 @@ class Base_Page(Borg):
 
     def set_rp_logger(self,rp_pytest_service):
         "Set the reportportal logger"
-        self.rp_logger = self.log_obj.setup_rp_logging(rp_pytest_service)
+        try:
+            self.rp_logger = self.log_obj.setup_rp_logging(rp_pytest_service)
+        except Exception as e:
+            self.exceptions.append("Error when setting up the reportportal logger")
 
 
     def append_latest_image(self,screenshot_name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests==2.31.0
 reportportal-client==5.5.4
-pytest==6.2.4 ; python_version =='3.6'
-pytest>6.2.4 ; python_version >='3.7'
+pytest==8.1.1
 selenium==4.12.0
 python_dotenv==0.16.0
 Appium_Python_Client==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Appium_Python_Client==3.2.0
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1
-pytest_reportportal==5.0.8
+pytest_reportportal>5.0.8
 pillow>=6.2.0
 tesults==1.2.1
 boto3==1.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Appium_Python_Client==3.2.0
 pytest-xdist>=1.31
 pytest-html>=3.0.0
 pytest-rerunfailures>=9.1.1
-pytest_reportportal>5.0.8
+pytest_reportportal==5.4.0
 pillow>=6.2.0
 tesults==1.2.1
 boto3==1.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-reportportal-client==5.0.10
+reportportal-client==5.5.4
 pytest==6.2.4 ; python_version =='3.6'
 pytest>6.2.4 ; python_version >='3.7'
 selenium==4.12.0

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -66,8 +66,7 @@ class Base_Logging():
         except Exception as e:
             self.write("Exception when trying to set rplogger")
             self.write(str(e))
-            self.exceptions.append("Error when setting up the reportportal logger")
-
+            
 
     def write(self,msg,level='info'):
         "Write out a message"

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -104,3 +104,4 @@ class Base_Logging():
             logger.critical("{module} | {msg}",module=d['caller_func'],msg=msg)
         else:
             logger.critical("Unknown level passed for the msg: {}", msg)
+            

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -66,7 +66,7 @@ class Base_Logging():
         except Exception as e:
             self.write("Exception when trying to set rplogger")
             self.write(str(e))
-            
+
 
     def write(self,msg,level='info'):
         "Write out a message"
@@ -104,4 +104,3 @@ class Base_Logging():
             logger.critical("{module} | {msg}",module=d['caller_func'],msg=msg)
         else:
             logger.critical("Unknown level passed for the msg: {}", msg)
-            

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -5,7 +5,7 @@ This class wraps around Python's loguru module.
 import os, inspect
 import logging
 from loguru import logger
-from pytest_reportportal import RPLogger, RPLogHandler
+from reportportal_client import RPLogger, RPLogHandler
 
 class Base_Logging():
     "A plug-n-play class for logging"


### PR DESCRIPTION
We are hitting a failure on CircleCI where requirements fail to install on python versions 3.8 and above.
This is because of incompatible` pytest-reportportal` and `reportportal-client` versions.
In this PR i have upgraded both the requirements and made a small change in the import in Base_logging page