### PR TITLE
Better exception handling

### DIFF
--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -698,8 +698,7 @@ class Base_Page(Borg):
         try:
             element = self.get_element(locator)
             action_obj = ActionChains(self.driver)
-            action_obj.move_to_element(element)
-            action_obj.perform()
+            action_obj.move_to_element(element).perform()
             self.wait(wait_seconds)
             result_flag = True  # Update the result flag to True if hover is successful
         except Exception as e:

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -799,7 +799,6 @@ class Base_Page(Borg):
         self.result_counter += 1
         self.failure_message_list.append(pre_format + msg)
         if level.lower() == 'critical':
-            self.teardown()
             raise Stop_Test_Exception("Stopping test because: "+ msg)
 
 

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -680,26 +680,32 @@ class Base_Page(Borg):
 
     def scroll_down(self,locator,wait_time=2):
         "Scroll down"
+        result_flag=False
         try:
             element = self.get_element(locator)
-            element.send_keys(Keys.PAGE_DOWN)
+            actions_obj = ActionChains(self.driver)
+            actions_obj.move_to_element(element).perform()
             self.wait(wait_time)
+            result_flag = True
         except Exception as e:
             self.write(str(e),'debug')
             self.exceptions.append("An exception occured when scrolling down")
-            return None
+        return result_flag
 
-
-    def hover(self,locator,wait_seconds=2):
+    def hover(self, locator, wait_seconds=2):
         "Hover over the element"
-        #Note: perform() of ActionChains does not return a bool
-        #So we have no way of returning a bool when hover is called
-        element = self.get_element(locator)
-        action_obj = ActionChains(self.driver)
-        action_obj.move_to_element(element)
-        action_obj.perform()
-        self.wait(wait_seconds)
-
+        result_flag = False  # Initialize the result flag to False
+        try:
+            element = self.get_element(locator)
+            action_obj = ActionChains(self.driver)
+            action_obj.move_to_element(element)
+            action_obj.perform()
+            self.wait(wait_seconds)
+            result_flag = True  # Update the result flag to True if hover is successful
+        except Exception as e:
+            self.write(str(e),'debug')
+            self.exceptions.append("An exception occured when hovering over the element", locator)
+        return result_flag
 
     def teardown(self):
         "Tears down the driver"

--- a/utils/Wrapit.py
+++ b/utils/Wrapit.py
@@ -3,6 +3,7 @@ Class to hold miscellaneous but useful decorators for our framework
 """
 
 from inspect import getfullargspec
+import traceback
 
 
 class Wrapit():
@@ -14,9 +15,10 @@ class Wrapit():
             try:
                 return f(*args,**kwargs)
             except Exception as e:
-                args[0].write('You have this exception')
-                args[0].write('Exception in method: %s'%str(f.__name__))
-                args[0].write('PYTHON SAYS: %s'%str(e))
+                trace = traceback.format_exc(limit=-1)
+                # Create a message with the traceback details
+                message = f"You have this exception: {str(e)}\n{trace}"
+                args[0].write(message, level='error')
                 #we denote None as failure case
                 return None
 


### PR DESCRIPTION
In this PR i have made the following changes
- Fixed the scroll down functionality
- Added code to Handle exceptions for hover functionality
- Removed call to teardown function when failure is hit, as teardown is already called in conftest.
-  Added Traceback to `Wrapit` `exception_handler` so as to trace the exact file and line where the exception occurred