### PR TITLE
Integrated LambdaTest cross-browser with framework

### DIFF
--- a/conf/remote_url_conf.py
+++ b/conf/remote_url_conf.py
@@ -2,3 +2,4 @@
 
 browserstack_url = "http://hub-cloud.browserstack.com/wd/hub"
 saucelabs_url = "https://ondemand.eu-central-1.saucelabs.com:443/wd/hub"
+lambdatest_url = "http://{}:{}@hub.lambdatest.com/wd/hub"

--- a/conftest.py
+++ b/conftest.py
@@ -44,7 +44,7 @@ def test_obj(request, base_url, browser, browser_version, os_version, os_name, r
             test_obj.set_rp_logger(reportportal_service)
 
         yield test_obj
-        
+
         #Teardown
         def fin():
             if os.getenv('REMOTE_BROWSER_PLATFORM') == 'LT' and remote_flag.lower() == 'y':

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,7 @@ def test_obj(request, base_url, browser, browser_version, os_version, os_name, r
             else:
                 test_obj.wait(3)
                 test_obj.teardown()
-                    
+
         request.addfinalizer(fin)
 
     except Exception as e:

--- a/integrations/lambdatest.py
+++ b/integrations/lambdatest.py
@@ -1,0 +1,43 @@
+import os
+from selenium import webdriver
+from integrations.remote_options import RemoteOptions
+from conf import remote_url_conf
+
+class LambdaTestRunner(RemoteOptions):
+    def __init__(self):
+        self.username = os.getenv('REMOTE_USERNAME')
+        self.password = os.getenv('REMOTE_ACCESS_KEY')
+        self.lambdatest_url = remote_url_conf.lambdatest_url.format(self.username, self.password)
+
+    def lambdatest_credentials(self, lambdatest_options):
+        """Set LambdaTest credentials."""
+        lambdatest_options['user'] = self.username
+        lambdatest_options['accessKey'] = self.password
+        return lambdatest_options
+
+    def run_lambdatest(self, os_name, os_version, browser, browser_version,
+                       remote_project_name, remote_build_name):
+        """Run the test in LambdaTest when remote flag is 'Y'."""
+        options = self.get_browser(browser, browser_version)
+
+        if options is None:
+            raise ValueError(f"Unsupported browser: {browser}")
+
+        # Set LambdaTest platform
+        options.platformName = f"{os_name} {os_version}"
+        
+        lambdatest_options = {}
+        lambdatest_options = self.lambdatest_credentials(lambdatest_options)
+        lambdatest_options["video"] = True
+        lambdatest_options["visual"] = False  # Make it true to capture screenshots
+        lambdatest_options["network"] = True
+        lambdatest_options["build"] = remote_build_name
+        lambdatest_options["project"] = remote_project_name
+        lambdatest_options["name"] = "UI Selenium Tests"
+        lambdatest_options["w3c"] = True
+        lambdatest_options["plugin"] = "python-pytest"
+        
+        options.set_capability('LT:options', lambdatest_options)
+        web_driver = webdriver.Remote(command_executor=self.lambdatest_url, options=options)
+
+        return web_driver

--- a/integrations/lambdatest.py
+++ b/integrations/lambdatest.py
@@ -8,6 +8,8 @@ class LambdaTestRunner(RemoteOptions):
         self.username = os.getenv('REMOTE_USERNAME')
         self.password = os.getenv('REMOTE_ACCESS_KEY')
         self.lambdatest_url = remote_url_conf.lambdatest_url.format(self.username, self.password)
+        self.session_id = None
+        self.session_url = None
 
     def lambdatest_credentials(self, lambdatest_options):
         """Set LambdaTest credentials."""
@@ -16,7 +18,7 @@ class LambdaTestRunner(RemoteOptions):
         return lambdatest_options
 
     def run_lambdatest(self, os_name, os_version, browser, browser_version,
-                       remote_project_name, remote_build_name):
+                       remote_project_name, remote_build_name, testname):
         """Run the test in LambdaTest when remote flag is 'Y'."""
         options = self.get_browser(browser, browser_version)
 
@@ -33,11 +35,37 @@ class LambdaTestRunner(RemoteOptions):
         lambdatest_options["network"] = True
         lambdatest_options["build"] = remote_build_name
         lambdatest_options["project"] = remote_project_name
-        lambdatest_options["name"] = "UI Selenium Tests"
+        lambdatest_options["name"] = testname
         lambdatest_options["w3c"] = True
         lambdatest_options["plugin"] = "python-pytest"
         
         options.set_capability('LT:options', lambdatest_options)
         web_driver = webdriver.Remote(command_executor=self.lambdatest_url, options=options)
 
+        # Store the session ID and session URL
+        self.session_id = web_driver.session_id
+
+        # Get the session URL
+        self.session_url = self.get_session_url_with_retries(self.session_id)
+
+        print(f"Session ID: {self.session_id}")
+        print(f"Session url: {self.session_url}")
+
         return web_driver
+    
+    def get_session_url_with_retries(self, session_id, retries=5, delay=2):
+        """Fetch the session URL using the LambdaTest API with retries."""
+        import requests,time
+        api_url = f"https://api.lambdatest.com/automation/api/v1/sessions/{session_id}"
+        for _ in range(retries):
+            response = requests.get(api_url, auth=(self.username, self.password))
+            if response.status_code == 200:
+                session_data = response.json()
+                test_id = session_data['data']['test_id']
+                return f"https://automation.lambdatest.com/test?testID={test_id}"
+            elif response.status_code == 404:
+                print(f"Retrying... Status code: {response.status_code}, Response: {response.text}")
+                time.sleep(delay)
+            else:
+                raise Exception(f"Failed to fetch session details. Status code: {response.status_code}, Response: {response.text}")
+        raise Exception(f"Failed to fetch session details after {retries} retries.")    

--- a/integrations/lambdatest.py
+++ b/integrations/lambdatest.py
@@ -27,7 +27,7 @@ class LambdaTestRunner(RemoteOptions):
 
         # Set LambdaTest platform
         options.platformName = f"{os_name} {os_version}"
-        
+
         lambdatest_options = {}
         lambdatest_options = self.lambdatest_credentials(lambdatest_options)
         lambdatest_options["video"] = True
@@ -38,7 +38,7 @@ class LambdaTestRunner(RemoteOptions):
         lambdatest_options["name"] = testname
         lambdatest_options["w3c"] = True
         lambdatest_options["plugin"] = "python-pytest"
-        
+
         options.set_capability('LT:options', lambdatest_options)
         web_driver = webdriver.Remote(command_executor=self.lambdatest_url, options=options)
 
@@ -68,4 +68,4 @@ class LambdaTestRunner(RemoteOptions):
                 time.sleep(delay)
             else:
                 raise Exception(f"Failed to fetch session details. Status code: {response.status_code}, Response: {response.text}")
-        raise Exception(f"Failed to fetch session details after {retries} retries.")    
+        raise Exception(f"Failed to fetch session details after {retries} retries.")

--- a/integrations/lambdatest.py
+++ b/integrations/lambdatest.py
@@ -52,7 +52,7 @@ class LambdaTestRunner(RemoteOptions):
         print(f"Session url: {self.session_url}")
 
         return web_driver
-    
+
     def get_session_url_with_retries(self, session_id, retries=5, delay=2):
         """Fetch the session URL using the LambdaTest API with retries."""
         import requests,time

--- a/integrations/remote_options.py
+++ b/integrations/remote_options.py
@@ -68,7 +68,7 @@ class RemoteOptions():
         """Set platform for saucelab."""
         options.platform_name = os_name + ' '+os_version
         return options
-    
+
     @staticmethod
     def sauce_upload(app_path, app_name):
         """Upload the apk to the sauce temperory storage."""

--- a/integrations/remote_options.py
+++ b/integrations/remote_options.py
@@ -44,7 +44,7 @@ class RemoteOptions():
         options.browser_version = browser_version
 
         return options
-    
+
     def get_browser(self, browser, browser_version):
         """Select the browser."""
         if browser.lower() == 'ff' or browser.lower() == 'firefox':

--- a/integrations/remote_options.py
+++ b/integrations/remote_options.py
@@ -44,13 +44,31 @@ class RemoteOptions():
         options.browser_version = browser_version
 
         return options
+    
+    def get_browser(self, browser, browser_version):
+        """Select the browser."""
+        if browser.lower() == 'ff' or browser.lower() == 'firefox':
+            desired_capabilities = self.firefox(browser_version)
+        elif browser.lower() == 'ie':
+            desired_capabilities = self.explorer(browser_version)
+        elif browser.lower() == 'chrome':
+            desired_capabilities = self.chrome(browser_version)
+        elif browser.lower() == 'opera':
+            desired_capabilities = self.opera(browser_version)
+        elif browser.lower() == 'safari':
+            desired_capabilities = self.safari(browser_version)
+        else:
+            print("\nDriverFactory does not know the browser\t%s\n" % browser)
+            desired_capabilities = None
+
+        return desired_capabilities
 
     @staticmethod
     def saucelab_platform(options, os_name, os_version):
         """Set platform for saucelab."""
         options.platform_name = os_name + ' '+os_version
         return options
-
+    
     @staticmethod
     def sauce_upload(app_path, app_name):
         """Upload the apk to the sauce temperory storage."""

--- a/page_objects/Base_Page.py
+++ b/page_objects/Base_Page.py
@@ -79,11 +79,11 @@ class Base_Page(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Objects, 
         "Switch the underlying class to the required Page"
         self.__class__ = PageFactory.PageFactory.get_page_object(page_name,base_url=self.base_url).__class__
 
-    def register_driver(self,remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name):
+    def register_driver(self,remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name,testname):
         "Register the driver with Page."
         self.set_screenshot_dir(os_name,os_version,browser,browser_version) # Create screenshot directory
         self.set_log_file()
-        self.driver = self.driver_obj.get_web_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name)
+        self.driver = self.driver_obj.get_web_driver(remote_flag,os_name,os_version,browser,browser_version,remote_project_name,remote_build_name,testname)
         self.driver.implicitly_wait(5)
         self.driver.maximize_window()
 

--- a/page_objects/core_helpers/selenium_action_objects.py
+++ b/page_objects/core_helpers/selenium_action_objects.py
@@ -306,6 +306,3 @@ class Selenium_Action_Objects:
             self.driver.quit()
             self.reset()
 
-        
-
-

--- a/page_objects/core_helpers/selenium_action_objects.py
+++ b/page_objects/core_helpers/selenium_action_objects.py
@@ -290,9 +290,22 @@ class Selenium_Action_Objects:
 
         return result_flag
 
-    def teardown(self):
+    def teardown(self, test_status = None):
         "Tears down the driver"
-        self.driver.quit()
-        self.reset()
+        import os
+        if os.getenv('REMOTE_BROWSER_PLATFORM') == 'LT' and test_status is not None:
+            if test_status == "fail":
+                # You can perform actions based on test failure
+                self.driver.execute_script("lambda-status=failed")
+            elif test_status == "pass":
+                # You can perform actions based on test success
+                self.driver.execute_script("lambda-status=passed")
+            self.driver.quit()
+            self.reset()
+        else:
+            self.driver.quit()
+            self.reset()
+
+        
 
 

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -97,7 +97,7 @@ class DriverFactory(RemoteOptions, LocalBrowsers, Capabilities):
         web_driver = webdriver.Remote(command_executor=browserstack_url, options=options)
 
         return web_driver
-    
+
     def run_sauce_lab(self, os_name, os_version, browser, browser_version):
         """Run the test in sauce labs when remote flag is 'Y'."""
         #Get the sauce labs credentials from sauce.credentials file

--- a/page_objects/driverfactory.py
+++ b/page_objects/driverfactory.py
@@ -33,12 +33,12 @@ class DriverFactory(RemoteOptions, LocalBrowsers, Capabilities):
         self.os_name = os_name
 
     def get_web_driver(self, remote_flag, os_name, os_version, browser,
-                       browser_version, remote_project_name, remote_build_name):
+                       browser_version, remote_project_name, remote_build_name, testname):
         """Return the appropriate driver."""
         if remote_flag.lower() == 'y':
             web_driver = self.select_remote_platform(remote_flag, os_name, os_version,
                                                      browser, browser_version, remote_project_name,
-                                                     remote_build_name)
+                                                     remote_build_name, testname)
 
         elif remote_flag.lower() == 'n':
             web_driver = self.run_local(browser)
@@ -46,18 +46,16 @@ class DriverFactory(RemoteOptions, LocalBrowsers, Capabilities):
         return web_driver
 
     def select_remote_platform(self, remote_flag, os_name, os_version, browser,
-                               browser_version, remote_project_name, remote_build_name):
+                               browser_version, remote_project_name, remote_build_name, testname):
         """Select the remote platform to run the test when the remote_flag is Y."""
         try:
             if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS':
                 web_driver = self.run_browserstack(os_name, os_version, browser, browser_version,
                                                    remote_project_name, remote_build_name)
             elif os.getenv('REMOTE_BROWSER_PLATFORM') == 'LT':
-                print("Inside select remote platform")
-                print("browser version =", browser_version)
                 runner = LambdaTestRunner()
                 web_driver = runner.run_lambdatest(os_name, os_version, browser, browser_version,
-                                                   remote_project_name, remote_build_name)
+                                                   remote_project_name, remote_build_name, testname)
             else:
                 web_driver = self.run_sauce_lab(os_name, os_version, browser, browser_version)
 


### PR DESCRIPTION
Integrated LambdaTest cross-browser with framework.

To run the test on LambdaTest, first set environmental variable REMOTE_BROWSER_PLATFORM = "LT" and provide correct LambdaTests Remote username and access key.

Now run the test with pytest command. for example:
`pytest -s -v tests/test_example_table.py --remote_flag Y --ver "125" --browser ff --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial
`