### PR TITLE
Fixed imageio deprecation warning issue

### DIFF
--- a/utils/Gif_Maker.py
+++ b/utils/Gif_Maker.py
@@ -2,7 +2,7 @@
 Qxf2 Services: This utility is for creating a GIF of all the screenshots captured during current test run
 
 """
-import imageio
+import imageio.v2 as imageio
 import os
 
 


### PR DESCRIPTION
To fix the deprecation warning message, importing  imageio v2 version.
Now, we can't see deprecation warning related to imageio at the end of run.