### PR TITLE
Added async API test, non-blocking HTTP methods

### DIFF
--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,3 @@
+# Skip flagging assert statement inclusion in test during Codacy check
+assert_used:
+  skips: ['*/test_*.py']

--- a/endpoints/API_Player.py
+++ b/endpoints/API_Player.py
@@ -230,3 +230,37 @@ class API_Player(Results):
             msg = "unknown reason"
 
         return {'result_flag': result_flag, 'msg': msg}
+
+    # Async methods
+    async def async_get_cars(self, auth_details=None):
+        "get available cars asynchronously"
+        headers = self.set_header_details(auth_details)
+        result = await self.api_obj.get_cars_async(headers)
+        result_flag = True if result["response"] == 200 else False
+        return result_flag
+
+    async def async_get_car(self, car_name, brand, auth_details=None):
+        "gets a given car details"
+        url_params = {'car_name': car_name, 'brand': brand}
+        url_params_encoded = urllib.parse.urlencode(url_params)
+        headers = self.set_header_details(auth_details)
+        response = await self.api_obj.get_car_async(url_params=url_params_encoded,
+                                              headers=headers)
+        result_flag = True if response['response'] == 200 else False
+        return result_flag
+
+    async def async_add_car(self, car_details, auth_details=None):
+        "adds a new car"
+        data = car_details
+        headers = self.set_header_details(auth_details)
+        response = await self.api_obj.add_car_async(data=data,
+                                                    headers=headers)
+        result_flag = True if response['response'] == 200 else False
+        return result_flag
+
+    async def async_get_registered_cars(self, auth_details=None):
+        "get registered cars"
+        headers = self.set_header_details(auth_details)
+        response = await self.api_obj.get_registered_cars_async(headers=headers)
+        result_flag = True if response['response'] == 200 else False
+        return result_flag

--- a/endpoints/Base_API.py
+++ b/endpoints/Base_API.py
@@ -2,16 +2,18 @@
 A wrapper around Requests to make Restful API calls
 """
 
+import asyncio
 from urllib.error import HTTPError
 from urllib.error import URLError
 
 class Base_API:
     "Main base class for Requests based scripts"
 
-    def get(self, url, headers={}):
+    def get(self, url, headers=None):
         "Get request"
         json_response = None
         error = {}
+        headers = headers if headers else {}
         try:
             response = self.request_obj.get(url=url,headers=headers)
             try:
@@ -37,11 +39,11 @@ class Base_API:
 
         return {'response': response.status_code,'text':response.text,'json_response':json_response, 'error': error}
 
-
-    def post(self, url,params=None, data=None,json=None,headers={}):
+    def post(self, url,params=None, data=None,json=None,headers=None):
         "Post request"
         error = {}
         json_response = None
+        headers = headers if headers else {}
         try:
             response = self.request_obj.post(url,params=params,json=json,headers=headers)
             try:
@@ -67,10 +69,11 @@ class Base_API:
         return {'response': response.status_code,'text':response.text,'json_response':json_response, 'error': error}
 
 
-    def delete(self, url,headers={}):
+    def delete(self, url,headers=None):
         "Delete request"
         response = False
         error = {}
+        headers = headers if headers else {}
         try:
             response = self.request_obj.delete(url,headers = headers)
             try:
@@ -97,10 +100,11 @@ class Base_API:
         return {'response': response.status_code,'text':response.text,'json_response':json_response, 'error': error}
 
 
-    def put(self,url,json=None, headers={}):
+    def put(self,url,json=None, headers=None):
         "Put request"
         error = {}
         response = False
+        headers = headers if headers else {}
         try:
             response = self.request_obj.put(url,json=json,headers=headers)
             try:
@@ -126,3 +130,37 @@ class Base_API:
             json_response = None
 
         return {'response': response.status_code,'text':response.text,'json_response':json_response, 'error': error}
+
+    async def async_get(self, url, headers=None):
+        "Run the blocking GET method in a thread"
+        headers = headers if headers else {}
+        response = await asyncio.to_thread(self.get, url, headers)
+        return response
+
+    async def async_post(self,
+                         url,
+                         params=None,
+                         data=None,
+                         json=None,
+                         headers=None):
+        "Run the blocking POST method in a thread"
+        headers = headers if headers else {}
+        response = await asyncio.to_thread(self.post,
+                                           url,
+                                           params,
+                                           data,
+                                           json,
+                                           headers)
+        return response
+
+    async def async_delete(self, url, headers=None):
+        "Run the blocking DELETE method in a thread"
+        headers = headers if headers else {}
+        response = await asyncio.to_thread(self.delete, url, headers)
+        return response
+
+    async def async_put(self, url, json=None, headers=None):
+        "Run the blocking PUT method in a thread"
+        headers = headers if headers else {}
+        response = await asyncio.to_thread(self.put, url, json, headers)
+        return response

--- a/endpoints/Cars_API_Endpoints.py
+++ b/endpoints/Cars_API_Endpoints.py
@@ -57,3 +57,25 @@ class Cars_API_Endpoints:
 			'url':url,
 			'response':json_response['json_response']
 		}
+
+	# Async methods
+	async def get_cars_async(self,headers):
+		"Get the list of cars"
+		url = self.cars_url()
+		response = await self.async_get(url,headers=headers)
+		return response
+
+
+	async def add_car_async(self,data,headers):
+		"Add a new car"
+		url = self.cars_url('/add')
+		response = await self.async_post(url,json=data,headers=headers)
+		return response
+
+
+	async def get_car_async(self,url_params,headers):
+		"Get car using URL params"
+		url = self.cars_url('/find?')+url_params
+		response = await self.async_get(url,headers=headers)
+		return response
+

--- a/endpoints/Registration_API_Endpoints.py
+++ b/endpoints/Registration_API_Endpoints.py
@@ -39,3 +39,12 @@ class Registration_API_Endpoints:
 		'url':url,
 		'response':json_response['json_response']
 		}
+
+
+	# Async methods
+	async def get_registered_cars_async(self,headers):
+		"Get registered cars"
+		url = self.registration_url('')
+		response = await self.async_get(url,headers=headers)
+		return response
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ axe_selenium_python==2.1.6
 pytest-snapshot==0.9.0
 beautifulsoup4>=4.12.3
 openai==1.12.0
+pytest-asyncio==0.23.7

--- a/tests/test_api_async_example.py
+++ b/tests/test_api_async_example.py
@@ -1,0 +1,69 @@
+"""
+API Async EXAMPLE TEST
+This test collects tasks using asyncio.TaskGroup object \
+and runs these scenarios asynchronously:
+1. Get the list of cars
+2. Add a new car
+3. Get a specifi car from the cars list
+4. Get the registered cars
+"""
+
+import asyncio
+import os
+import sys
+import pytest
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from conf import api_example_conf
+
+@pytest.mark.API
+# Skip running the test if Python version < 3.11
+@pytest.mark.skipif(sys.version_info < (3,11),
+                    reason="requires Python3.11 or higher")
+async def test_api_async_example(test_api_obj):
+    "Run api test"
+    try:
+        expected_pass = 0
+        actual_pass = -1
+
+        # set authentication details
+        username = api_example_conf.user_name
+        password = api_example_conf.password
+        auth_details = test_api_obj.set_auth_details(username, password)
+
+        # Get an existing car detail from conf
+        existing_car = api_example_conf.car_name_1
+        brand = api_example_conf.brand
+        # Get a new car detail from conf
+        car_details = api_example_conf.car_details
+
+        async with asyncio.TaskGroup() as group:
+            get_cars = group.create_task(test_api_obj.async_get_cars(auth_details))
+            add_new_car = group.create_task(test_api_obj.async_add_car(car_details=car_details,
+                                                                       auth_details=auth_details))
+            get_car = group.create_task(test_api_obj.async_get_car(auth_details=auth_details,
+                                                                   car_name=existing_car,
+                                                                   brand=brand))
+            get_reg_cars = group.create_task(test_api_obj.async_get_registered_cars(auth_details=auth_details))
+
+        test_api_obj.log_result(get_cars.result(),
+                                positive="Successfully obtained the list of cars",
+                                negative="Failed to get the cars")
+        test_api_obj.log_result(add_new_car.result(),
+                                positive=f"Successfully added new car {car_details}",
+                                negative="Failed to add a new car")
+        test_api_obj.log_result(get_car.result(),
+                                positive=f"Successfully obtained a car - {existing_car}",
+                                negative="Failed to add a new car")
+        test_api_obj.log_result(get_reg_cars.result(),
+                                positive="Successfully obtained registered cars",
+                                negative="Failed to get registered cars")
+        # write out test summary
+        expected_pass = test_api_obj.total
+        actual_pass = test_api_obj.passed
+        test_api_obj.write_test_summary()
+        # Assertion
+        assert expected_pass == actual_pass,f"Test failed: {__file__}"
+
+    except Exception as e:
+        test_api_obj.write(f"Exception when trying to run test: {__file__}")
+        test_api_obj.write(f"Python says: {str(e)}")


### PR DESCRIPTION
Added:
> 1. An `Async` API test that uses `TaskGroup` to collect and run non-blocking tasks
> 2. Non-blocking functions for existing `HTTP` request functions
> 3. `Async` abstract methods in `API_Player`

How to run the test:
> Run `python -m pip install -r requirements.txt` to install `pytest-async` package, this package is needed to run the test function in an event loop
> Use `python -m pytest -k async` to run the `Async` API test

Caveat:
> The `Async` API test can only be run with `Python3.11` or higher, a `pytest` marker is used to skip running tests on `Python` < `3.11`