### PR TITLE
outdated parser entries commented in pytest_addoption() method as tho…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -604,10 +604,10 @@ def pytest_generate_tests(metafunc):
 def pytest_addoption(parser):
     "Method to add the option to ini."
     try:
-        parser.addini("rp_uuid",'help',type="pathlist")
-        parser.addini("rp_endpoint",'help',type="pathlist")
-        parser.addini("rp_project",'help',type="pathlist")
-        parser.addini("rp_launch",'help',type="pathlist")
+        #parser.addini("rp_uuid",'help',type="pathlist")
+        #parser.addini("rp_endpoint",'help',type="pathlist")
+        #parser.addini("rp_project",'help',type="pathlist")
+        #parser.addini("rp_launch",'help',type="pathlist")
 
         parser.addoption("--browser",
                             dest="browser",

--- a/conftest.py
+++ b/conftest.py
@@ -603,7 +603,6 @@ def pytest_generate_tests(metafunc):
 
 def pytest_addoption(parser):
     "Method to add the option to ini."
-    
     try:
         parser.addoption("--browser",
                             dest="browser",

--- a/conftest.py
+++ b/conftest.py
@@ -603,12 +603,8 @@ def pytest_generate_tests(metafunc):
 
 def pytest_addoption(parser):
     "Method to add the option to ini."
+    
     try:
-        #parser.addini("rp_uuid",'help',type="pathlist")
-        #parser.addini("rp_endpoint",'help',type="pathlist")
-        #parser.addini("rp_project",'help',type="pathlist")
-        #parser.addini("rp_launch",'help',type="pathlist")
-
         parser.addoption("--browser",
                             dest="browser",
                             action="append",


### PR DESCRIPTION
The below entries are not required and are commented entries in the method 'pytest_addoption()' method.

         parser.addini("rp_uuid",'help',type="pathlist")
        parser.addini("rp_endpoint",'help',type="pathlist")
        parser.addini("rp_project",'help',type="pathlist")
        parser.addini("rp_launch",'help',type="pathlist")

Tested the changes By keeping the four entries with report portal integration.
Tested the changes by commenting the four entries with report portal integration.

Please review