### PR TITLE
Modified the Async API test to use the right pytest marker

### DIFF
--- a/tests/test_api_async_example.py
+++ b/tests/test_api_async_example.py
@@ -15,7 +15,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from conf import api_example_conf
 
-@pytest.mark.API
+@pytest.mark.asyncio
 # Skip running the test if Python version < 3.11
 @pytest.mark.skipif(sys.version_info < (3,11),
                     reason="requires Python3.11 or higher")


### PR DESCRIPTION
Modified the test to replace the old marker - `@pytest.mark.API` with the required `@pytest.mark.asyncio` marker.

Ran the test on `Python3.11` & `Python < 3.11` to make sure that the test is run on `Python3.11` and skipped in `Python < 3.11`