### PR TITLE
Upload tests terminal logs to Browserstack and fixed incomplete consolidated logs issue

### DIFF
--- a/conf/remote_url_conf.py
+++ b/conf/remote_url_conf.py
@@ -2,7 +2,8 @@
 
 browserstack_url = "http://hub-cloud.browserstack.com/wd/hub"
 browserstack_app_upload_url = "https://api-cloud.browserstack.com/app-automate/upload"
-browserstack_api_server_url = "https://api.browserstack.com/automate/"
+browserstack_api_server_url = "https://api.browserstack.com/automate"
+browserstack_cloud_api_server_url = "https://api-cloud.browserstack.com"
 saucelabs_url = "https://ondemand.eu-central-1.saucelabs.com:443/wd/hub"
 saucelabs_app_upload_url = 'https://api.eu-central-1.saucelabs.com/v1/storage/upload'
 lambdatest_url = "http://{}:{}@hub.lambdatest.com/wd/hub"

--- a/conftest.py
+++ b/conftest.py
@@ -168,17 +168,17 @@ def upload_test_logs_to_browserstack(log_name, session_url, appium_test = False)
         # Check if the log file exists
         if not os.path.isfile(log_file):
             raise FileNotFoundError(f"Log file '{log_file}' not found.")
-        
+
         # Extract session ID from the provided session URL
         session_id = browserstack_obj.extract_session_id(session_url)
         if not session_id:
             raise ValueError(f"Invalid session URL provided: '{session_url}'")
-        
+
         # Upload the log file to BrowserStack
         response = browserstack_obj.upload_terminal_logs(log_file,session_id,appium_test)
 
         return response
-    
+
     except ImportError as e:
         return {"error": "Failed to import BrowserStack_Library.", "details": str(e)}
 

--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
 
         else:
             test_obj.wait(3)
-            test_obj.teardown()   
+            test_obj.teardown()
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
@@ -143,7 +143,7 @@ def upload_test_logs_to_browserstack(log_name, session_url, appium_test = False)
     from integrations.cross_browsers.BrowserStack_Library import BrowserStack_Library # pylint: disable=import-error,import-outside-toplevel
     browserstack_obj = BrowserStack_Library()
     log_file_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),'log'))
-    log_file = log_file_dir + os.sep + 'temp_' + log_name 
+    log_file = log_file_dir + os.sep + 'temp_' + log_name
     session_id = browserstack_obj.extract_session_id(session_url)
     response = browserstack_obj.upload_terminal_logs(log_file,session_id,appium_test)
 
@@ -166,7 +166,7 @@ def testname(request):
 def browser(request):
     "pytest fixture for browser"
     try:
-       return request.config.getoption("--browser")
+        return request.config.getoption("--browser")
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
@@ -447,8 +447,8 @@ def reportportal_service(request):
     "pytest service fixture for reportportal"
     reportportal_pytest_service = None
     try:
-       if request.config.getoption("--reportportal"):
-           reportportal_pytest_service = request.node.config.py_test_service
+        if request.config.getoption("--reportportal"):
+            reportportal_pytest_service = request.node.config.py_test_service
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))

--- a/conftest.py
+++ b/conftest.py
@@ -158,7 +158,6 @@ def upload_test_logs_to_browserstack(log_name, session_url, appium_test = False)
     "Upload log file to provided BrowserStack session"
     try:
         from integrations.cross_browsers.BrowserStack_Library import BrowserStack_Library # pylint: disable=import-error,import-outside-toplevel
-        
         # Initialize BrowserStack object
         browserstack_obj = BrowserStack_Library()
 

--- a/core_helpers/mobile_app_helper.py
+++ b/core_helpers/mobile_app_helper.py
@@ -78,7 +78,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
         self.set_screenshot_dir() # Create screenshot directory
         self.set_log_file()
         if self.session_url:
-            self.write( "Cloud Session URL: " + '\n' + str(self.session_url))
+            self.write( "Cloud Session URL for test: " + self.calling_module + '\n' + str(self.session_url))
         self.start()
 
 

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -85,7 +85,7 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
         self.driver,self.session_url = self.driver_obj.get_web_driver(remote_flag,os_name,os_version,browser,browser_version,
                                                                           remote_project_name,remote_build_name,testname)
         if self.session_url:
-            self.write( "Cloud Session URL: " + '\n' + str(self.session_url))
+            self.write( "Cloud Session URL for test: " + self.calling_module + '\n' + str(self.session_url))
         self.driver.implicitly_wait(5)
         self.driver.maximize_window()
 

--- a/integrations/cross_browsers/BrowserStack_Library.py
+++ b/integrations/cross_browsers/BrowserStack_Library.py
@@ -17,6 +17,7 @@ class BrowserStack_Library():
     def __init__(self):
         "Constructor for the BrowserStack library"
         self.browserstack_api_server_url = remote_url_conf.browserstack_api_server_url
+        self.browserstack_cloud_api_server_url = remote_url_conf.browserstack_cloud_api_server_url
         self.auth = self.get_auth()
 
 
@@ -31,7 +32,7 @@ class BrowserStack_Library():
 
     def get_build_id(self,timeout=10):
         "Get the build ID"
-        build_url = self.browserstack_api_server_url + "builds.json?status=running"
+        build_url = self.browserstack_api_server_url + "/builds.json?status=running"
         builds = requests.get(build_url, auth=self.auth, timeout=timeout).json()
         build_id =  builds[0]['automation_build']['hashed_id']
 
@@ -60,11 +61,33 @@ class BrowserStack_Library():
 
         return session_details
 
+    def extract_session_id(self, session_url):
+        "Extract session id from session url"
+        import re
+        # Use regex to match the session ID, which is a 40-character hexadecimal string
+        match = re.search(r'/sessions/([a-f0-9]{40})', session_url)
+        if match:
+            return match.group(1)
+        else:
+            return None
 
-    def get_session_logs(self, timeout=10):
-        "Return the session log in text format"
-        session_details = self.get_active_session_details()
-        session_log_url = session_details['logs']
-        session_log = requests.get(f'{session_log_url}',auth=self.auth,timeout=timeout).text
+    def upload_terminal_logs(self, file_path, session_id = None, appium_test = False, timeout=30):
+        "Upload the terminal log to BrowserStack"
+        if session_id is None:
+            session_details = self.get_active_session_details()
+            session_id = session_details['hashed_id']
+        # File to be uploaded
+        files = {'file': open(file_path, 'rb')}
+        if appium_test:
+            url = f'{self.browserstack_cloud_api_server_url}/app-automate/sessions/{session_id}/terminallogs'
+        else:
+            url = f'{self.browserstack_cloud_api_server_url}/automate/sessions/{session_id}/terminallogs'
+        response= requests.post(url, auth=self.auth, files=files, timeout=timeout)
+        # Check if the request was successful
+        if response.status_code == 200:
+            print("Log file uploaded to BrowserStack session successfully.")
+        else:
+            print(f"Failed to upload log file. Status code: {response.status_code}")
+            print(response.text)
 
-        return session_log
+        return response

--- a/integrations/cross_browsers/BrowserStack_Library.py
+++ b/integrations/cross_browsers/BrowserStack_Library.py
@@ -92,7 +92,7 @@ class BrowserStack_Library():
                 files = {'file': file}
                 # Make the POST request to upload the file
                 response = requests.post(url, auth=self.auth, files=files, timeout=timeout)
-                
+
             # Check if the request was successful
             if response.status_code == 200:
                 print("Log file uploaded to BrowserStack session successfully.")

--- a/utils/Base_Logging.py
+++ b/utils/Base_Logging.py
@@ -21,6 +21,7 @@ class Base_Logging():
         self.set_log(self.log_file_name,self.level)
         self.rp_logger = None
 
+
     def set_log(self,log_file_name,level,log_format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}",test_module_name=None):
         "Add an handler sending log messages to a sink"
         if test_module_name is None:
@@ -29,13 +30,15 @@ class Base_Logging():
             os.makedirs(self.log_file_dir)
         if log_file_name is None:
             log_file_name = self.log_file_dir + os.sep + test_module_name + '.log'
+            temp_log_file_name = self.log_file_dir + os.sep + 'temp_' + test_module_name + '.log'
         else:
+            temp_log_file_name = self.log_file_dir + os.sep + 'temp_' + log_file_name
             log_file_name = self.log_file_dir + os.sep + log_file_name
 
         logger.add(log_file_name,level=level, format=log_format,
         rotation="30 days", filter=None, colorize=None, serialize=False, backtrace=True, enqueue=False, catch=True)
         # Create temporary log files for consolidating log data of all tests of a session to a single file
-        logger.add(log_file_name + '-temp',level=level, format=log_format,
+        logger.add(temp_log_file_name,level=level, format=log_format,
         rotation="30 days", filter=None, colorize=None, serialize=False, backtrace=True, enqueue=False, catch=True)
 
 
@@ -125,6 +128,7 @@ class Base_Logging():
             logger.opt(colors=True).critical("<cyan>{file_name}</cyan>::<yellow>{module}</yellow> | {msg}", file_name=file_name, module=module, msg=msg)
         else:
             logger.critical("Unknown level passed for the msg: {}", msg)
+
 
     def get_exception_module(self,trace_back):
         "Get the actual name of the calling module where exception arises"


### PR DESCRIPTION
- Added methods to extract the session_id from session_url and upload terminal logs to BrowserStack. Methods works fine for both Selenium and Appium tests. Updated conf file with api endpoint server url
- Updated temp log naming as BrowserStack supports .log, .json and .txt file extensions only. It is not supporting .log-temp extension.  So changed file name from `(test_name).log-temp` to `temp_(test_name).log`
- Fixed incomplete consolidated log issue, issues was happening because pytest hooks pytest_sessionstart and pytest_sessionfinish get executes the code when tests run in parallel. Which was deleting all temp log files before generating the consolidated logs. Now updated pytest_sessionstart and pytest_sessionfinish hook code to execute during main_session only.
- Sending Selenium and Appium test terminal logs to BrowserStack successfully. 