### PR TITLE
Resolve the logging message when invalid Browserstack credentials as provided

### DIFF
--- a/integrations/cross_browsers/browserstack_runner.py
+++ b/integrations/cross_browsers/browserstack_runner.py
@@ -56,6 +56,7 @@ class BrowserStackRunner(RemoteOptions):
             post_json_data = json.loads(post_response.text)
             #Get the app url of the newly uploaded apk
             app_url = post_json_data['app_url']
+            
             return app_url
 
         except Exception as exception:

--- a/integrations/cross_browsers/browserstack_runner.py
+++ b/integrations/cross_browsers/browserstack_runner.py
@@ -52,13 +52,14 @@ class BrowserStackRunner(RemoteOptions):
             files = {'file': open(apk_file, 'rb')}
             post_response = requests.post(self.browserstack_app_upload_url, files=files,
                                          auth=(self.username, self.password),timeout= timeout)
+            post_response.raise_for_status()
             post_json_data = json.loads(post_response.text)
             #Get the app url of the newly uploaded apk
             app_url = post_json_data['app_url']
-        except Exception as exception:
-            print(str(exception))
+            return app_url
 
-        return app_url
+        except Exception as exception:
+            print('\033[91m'+"\nError while uploading the app:%s"%str(exception)+'\033[0m')
 
     def get_current_session_url(self, web_driver):
         "Get current session url"

--- a/integrations/cross_browsers/browserstack_runner.py
+++ b/integrations/cross_browsers/browserstack_runner.py
@@ -56,7 +56,6 @@ class BrowserStackRunner(RemoteOptions):
             post_json_data = json.loads(post_response.text)
             #Get the app url of the newly uploaded apk
             app_url = post_json_data['app_url']
-            
             return app_url
 
         except Exception as exception:


### PR DESCRIPTION
- When invalid Browserstack credentials are provided, the logging message complains about the 'app_url' not being found rather than the actual error. 
- This is because we are not handling the HTTP request errors in the method to upload the app to Browserstack.
- This PR resolves the issue by handling the HTTP exceptions

![http_error](https://github.com/user-attachments/assets/37178b76-b452-474e-be13-f73e13f206ff)
