### PR TITLE
Update BrowserStack Session Status

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,16 +43,22 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
 
         yield test_obj
 
-        #Teardown
+        #Update test run status to respective LambdaTest session
         if os.getenv('REMOTE_BROWSER_PLATFORM') == 'LT' and remote_flag.lower() == 'y':
             if test_obj.pass_counter == test_obj.result_counter:
                 test_obj.execute_javascript("lambda-status=passed")
-                test_obj.teardown()
             else:
                 test_obj.execute_javascript("lambda-status=failed")
-                test_obj.teardown()
 
         elif os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
+            #Update test run status to respective BrowserStack session
+            if test_obj.pass_counter == test_obj.result_counter:
+                test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
+                test_obj.write("BrowserStack Test Session Status: PASS")
+            else:
+                test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
+                test_obj.write("BrowserStack Test Session Status: FAILED",level='error')
+
             #Upload test logs to BrowserStack
             response = upload_test_logs_to_browserstack(test_obj.log_name,test_obj.session_url)
             if isinstance(response, dict) and "error" in response:
@@ -69,13 +75,11 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
                     test_obj.write(f"Failed to upload log file. Status code: {response.status_code}",level='error')
                     test_obj.write(response.text,level='error')
 
-            #Update test run status to respective BrowserStack session
-            update_browserstack_session_status(test_obj)
-            test_obj.teardown()
-
         else:
             test_obj.wait(3)
-            test_obj.teardown()
+
+        #Teardown
+        test_obj.teardown()
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
@@ -114,13 +118,22 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
         yield test_mobile_obj
 
         if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
+            #Update test run status to respective BrowserStack session
+            if test_mobile_obj.pass_counter == test_mobile_obj.result_counter:
+                test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
+                test_mobile_obj.write("BrowserStack Test Session Status: PASS")
+            else:
+                test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
+                test_mobile_obj.write("BrowserStack Test Session Status: FAILED",level='error')
+
+            #Upload test logs to BrowserStack
             response = upload_test_logs_to_browserstack(test_mobile_obj.log_name,test_mobile_obj.session_url,appium_test = True)
             if isinstance(response, dict) and "error" in response:
                 # Handle the error response returned as a dictionary
-                test_obj.write(f"Error: {response['error']}",level='error')
+                test_mobile_obj.write(f"Error: {response['error']}",level='error')
                 if "details" in response:
-                    test_obj.write(f"Details: {response['details']}",level='error')
-                    test_obj.write("Failed to upload log file to BrowserStack",level='error')
+                    test_mobile_obj.write(f"Details: {response['details']}",level='error')
+                    test_mobile_obj.write("Failed to upload log file to BrowserStack",level='error')
             else:
                 # Handle the case where the response is assumed to be a response object
                 if response.status_code == 200:
@@ -129,9 +142,6 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
                     test_mobile_obj.write(f"Failed to upload log file. Status code: {response.status_code}",level='error')
                     test_mobile_obj.write(response.text,level='error')
 
-            #Update test run status to respective BrowserStack session
-            update_browserstack_session_status(test_mobile_obj)
-
         #Teardown
         test_mobile_obj.wait(3)
         test_mobile_obj.teardown()
@@ -139,6 +149,8 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))
+        if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
+            test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Exception occured"}}')
 
 @pytest.fixture
 def test_api_obj(request, interactivemode_flag, api_url=base_url_conf.api_base_url):
@@ -160,13 +172,6 @@ def test_api_obj(request, interactivemode_flag, api_url=base_url_conf.api_base_u
     except Exception as e:
         print("Exception when trying to run test:%s" % __file__)
         print("Python says:%s" % str(e))
-
-def update_browserstack_session_status(test_obj):
-    "Update BrowserStack session status with test run status"
-    if test_obj.pass_counter == test_obj.result_counter:
-        test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
-    else:
-        test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
 
 def upload_test_logs_to_browserstack(log_name, session_url, appium_test = False):
     "Upload log file to provided BrowserStack session"

--- a/conftest.py
+++ b/conftest.py
@@ -51,14 +51,6 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
                 test_obj.execute_javascript("lambda-status=failed")
 
         elif os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
-            #Update test run status to respective BrowserStack session
-            if test_obj.pass_counter == test_obj.result_counter:
-                test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
-                test_obj.write("BrowserStack Test Session Status: PASS")
-            else:
-                test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
-                test_obj.write("BrowserStack Test Session Status: FAILED",level='error')
-
             #Upload test logs to BrowserStack
             response = upload_test_logs_to_browserstack(test_obj.log_name,test_obj.session_url)
             if isinstance(response, dict) and "error" in response:
@@ -75,10 +67,25 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
                     test_obj.write(f"Failed to upload log file. Status code: {response.status_code}",level='error')
                     test_obj.write(response.text,level='error')
 
+            #Update test run status to respective BrowserStack session
+            if test_obj.pass_counter == test_obj.result_counter:
+                test_obj.write("Test Status: PASS")
+                result_flag = test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
+                test_obj.conditional_write(result_flag,
+                                           positive="Successfully set BrowserStack Test Session Status to PASS",
+                                           negative="Failed to set Browserstack session status to PASS")
+            else:
+                test_obj.write("Test Status: FAILED",level='error')
+                result_flag = test_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
+                test_obj.conditional_write(result_flag,
+                                           positive="Successfully set BrowserStack Test Session Status to FAILED",
+                                           negative="Failed to set Browserstack session status to FAILED")
+
         else:
             test_obj.wait(3)
 
         #Teardown
+        test_obj.write("*************************\n")
         test_obj.teardown()
 
     except Exception as e:
@@ -118,14 +125,6 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
         yield test_mobile_obj
 
         if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
-            #Update test run status to respective BrowserStack session
-            if test_mobile_obj.pass_counter == test_mobile_obj.result_counter:
-                test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
-                test_mobile_obj.write("BrowserStack Test Session Status: PASS")
-            else:
-                test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
-                test_mobile_obj.write("BrowserStack Test Session Status: FAILED",level='error')
-
             #Upload test logs to BrowserStack
             response = upload_test_logs_to_browserstack(test_mobile_obj.log_name,test_mobile_obj.session_url,appium_test = True)
             if isinstance(response, dict) and "error" in response:
@@ -142,8 +141,23 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
                     test_mobile_obj.write(f"Failed to upload log file. Status code: {response.status_code}",level='error')
                     test_mobile_obj.write(response.text,level='error')
 
+            #Update test run status to respective BrowserStack session
+            if test_mobile_obj.pass_counter == test_mobile_obj.result_counter:
+                test_mobile_obj.write("Test Status: PASS")
+                result_flag = test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": "All test cases passed"}}')
+                test_mobile_obj.conditional_write(result_flag,
+                                           positive="Successfully set BrowserStack Test Session Status to PASS",
+                                           negative="Failed to set Browserstack session status to PASS")
+            else:
+                test_mobile_obj.write("Test Status: FAILED",level='error')
+                result_flag = test_mobile_obj.execute_javascript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": "Test failed. Look at terminal logs for more details"}}')
+                test_mobile_obj.conditional_write(result_flag,
+                                           positive="Successfully set BrowserStack Test Session Status to FAILED",
+                                           negative="Failed to set Browserstack session status to FAILED")
+
         #Teardown
         test_mobile_obj.wait(3)
+        test_mobile_obj.write("*************************\n")
         test_mobile_obj.teardown()
 
     except Exception as e:

--- a/core_helpers/selenium_action_objects.py
+++ b/core_helpers/selenium_action_objects.py
@@ -307,3 +307,13 @@ class Selenium_Action_Objects:
         except Exception as e:
             print(f"An error occured during keyboard minimise: {str(e)}")
             return result_flag
+
+    def execute_javascript(self,js_script,*args):
+        "Execute javascipt"
+        try:
+            self.driver.execute_script(js_script)
+            result_flag = True
+        except Exception as e:
+            result_flag = False
+
+        return result_flag

--- a/core_helpers/selenium_action_objects.py
+++ b/core_helpers/selenium_action_objects.py
@@ -306,14 +306,16 @@ class Selenium_Action_Objects:
             result_flag=True
         except Exception as e:
             print(f"An error occured during keyboard minimise: {str(e)}")
-            return result_flag
+
+        return result_flag
 
     def execute_javascript(self,js_script,*args):
-        "Execute javascipt"
+        "Execute javascript"
         try:
             self.driver.execute_script(js_script)
             result_flag = True
         except Exception as e:
+            print(f"An error occured during javascript execution: {str(e)}")
             result_flag = False
 
         return result_flag

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -327,16 +327,6 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             else:
                 self.write(negative,level='error')
 
-    def execute_javascript(self,js_script,*args):
-        "Execute javascipt"
-        try:
-            self.driver.execute_script(js_script)
-            result_flag = True
-        except Exception as e:
-            result_flag = False
-
-        return result_flag
-
     def start(self):
         "Overwrite this method in your Page module if you want to visit a specific URL"
         pass


### PR DESCRIPTION
- Added a way to update the BrowserStack session status with test run status
- Moved execute java script method to selenium action objects file from web app helper file so we can access it for both Web app and Mobile App test

Look at the attached screenshots to look at staus update:
When test pass:
![session status pass](https://github.com/user-attachments/assets/b8440d44-7822-4c59-99dc-403366e62289)
When test fail:
![session status failed](https://github.com/user-attachments/assets/7e43bad9-89b4-470b-b574-c0d0560ab09e)

