### PR TITLE
Reduce CircleCI build time

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/weather-shopper-app-apk/app/
 
 #Command to run the test
-commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 2 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/weather-shopper-app-apk/app/
 
 #Command to run the test
-commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 2 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py


### PR DESCRIPTION
Presently, we are running 3 containers in parallel. Now modified test run commands to run tests in parallel. Test command runs 3 tests in parallel in each container.

And, now build time is reduced by almost 55 to 60%.  