### PR TITLE
Linking the remote options

### DIFF
--- a/conf/browser_os_name_conf.py
+++ b/conf/browser_os_name_conf.py
@@ -14,7 +14,7 @@ local_browsers = ["firefox","chrome"]  #local browser list against which tests w
 #change this depending on your client
 
 browsers = ["firefox","chrome","safari"]  #browsers to generate test run configuration to run on Browserstack/Sauce Labs
-firefox_versions = ["123","122"]  #firefox versions for the tests to run against on Browserstack/Sauce Labs
+firefox_versions = ["121","122"]  #firefox versions for the tests to run against on Browserstack/Sauce Labs
 chrome_versions = ["121","122"]  #chrome versions for the tests to run against on Browserstack/Sauce Labs
 safari_versions = ["15.3"]  #safari versions for the tests to run against on Browserstack/Sauce Labs
 os_list = ["windows","OS X"]   #list of os for the tests to run against on Browserstack/Sauce Labs

--- a/conf/browser_os_name_conf.py
+++ b/conf/browser_os_name_conf.py
@@ -14,15 +14,19 @@ local_browsers = ["firefox","chrome"]  #local browser list against which tests w
 #change this depending on your client
 
 browsers = ["firefox","chrome","safari"]  #browsers to generate test run configuration to run on Browserstack/Sauce Labs
-firefox_versions = ["121","122"]  #firefox versions for the tests to run against on Browserstack/Sauce Labs
+firefox_versions = ["123","122"]  #firefox versions for the tests to run against on Browserstack/Sauce Labs
 chrome_versions = ["121","122"]  #chrome versions for the tests to run against on Browserstack/Sauce Labs
 safari_versions = ["15.3"]  #safari versions for the tests to run against on Browserstack/Sauce Labs
 os_list = ["windows","OS X"]   #list of os for the tests to run against on Browserstack/Sauce Labs
 windows_versions = ["10","11"]  #list of windows versions for the tests to run against on Browserstack/Sauce Labs
 os_x_versions = ["Monterey"]   #list of os x versions for the tests to run against on Browserstack/Sauce Labs
 sauce_labs_os_x_versions = ["10.10"] #Set if running on sauce_labs instead of "yosemite"
-default_config_list = [("chrome","121","windows","11")] #default configuration against which the test would run if no -B all option is used
-
+default_config_list = [("chrome","latest","windows","11")] #default configuration against which the test would run if no -B all option is used
+# Define default os versions based on os
+default_os_versions = {
+    "windows": "11",
+    "os x": "sequoia"
+}
 
 def generate_configuration(browsers=browsers,firefox_versions=firefox_versions,chrome_versions=chrome_versions,safari_versions=safari_versions,
                             os_list=os_list,windows_versions=windows_versions,os_x_versions=os_x_versions):

--- a/conftest.py
+++ b/conftest.py
@@ -593,7 +593,7 @@ def pytest_configure(config):
 
     # Set default versions for browsers that don't have versions specified
     if browser and not version:
-        for b in browser:
+        for browser_name in browser:
             version.append("latest")
 
     if os_name and not os_version:

--- a/conftest.py
+++ b/conftest.py
@@ -581,7 +581,6 @@ def pytest_configure(config):
     version = config.getoption("browser_version")
     os_name = config.getoption("os_name")
     os_version = config.getoption("os_version")
-    print(f"Browser: {browser}, Version: {version}")
 
     # Check if version is specified without a browser
     if version and not browser:
@@ -590,20 +589,21 @@ def pytest_configure(config):
     if os_version and not os_name:
         raise ValueError("You have specified an OS version without setting an OS. Please use the --os_name option to specify the OS.")
 
-    # Define default versions based on browser
-    default_versions = {
-        "firefox": "115",
-        "chrome": "121"
-    }
+    default_os_versions = browser_os_name_conf.default_os_versions
 
     # Set default versions for browsers that don't have versions specified
     if browser and not version:
         for b in browser:
-            if b.lower() in default_versions:
-                version.append(default_versions[b.lower()])
+            version.append("latest")
+
+    if os_name and not os_version:
+        for os in os_name:
+            if os.lower() in default_os_versions:
+                os_version.append(default_os_versions[os.lower()])
             else:
-                raise ValueError(f"No default version available for browser '{b}'. Please specify a version using --ver.")
-    
+                raise ValueError(f"No default version available for browser '{os}'. Please specify a version using --ver.")
+
+
     # Assign back the modified version list to config (in case it was updated)
     config.option.browser_version = version    
 

--- a/conftest.py
+++ b/conftest.py
@@ -577,6 +577,36 @@ def pytest_sessionfinish(session, exitstatus):
 @pytest.hookimpl()
 def pytest_configure(config):
     "Sets the launch name based on the marker selected."
+    browser = config.getoption("browser")
+    version = config.getoption("browser_version")
+    os_name = config.getoption("os_name")
+    os_version = config.getoption("os_version")
+    print(f"Browser: {browser}, Version: {version}")
+
+    # Check if version is specified without a browser
+    if version and not browser:
+        raise ValueError("You have specified a browser version without setting a browser. Please use the --browser option to specify the browser.")
+
+    if os_version and not os_name:
+        raise ValueError("You have specified an OS version without setting an OS. Please use the --os_name option to specify the OS.")
+
+    # Define default versions based on browser
+    default_versions = {
+        "firefox": "115",
+        "chrome": "121"
+    }
+
+    # Set default versions for browsers that don't have versions specified
+    if browser and not version:
+        for b in browser:
+            if b.lower() in default_versions:
+                version.append(default_versions[b.lower()])
+            else:
+                raise ValueError(f"No default version available for browser '{b}'. Please specify a version using --ver.")
+    
+    # Assign back the modified version list to config (in case it was updated)
+    config.option.browser_version = version    
+
     global if_reportportal
     if_reportportal =config.getoption('--reportportal')
 

--- a/conftest.py
+++ b/conftest.py
@@ -593,19 +593,18 @@ def pytest_configure(config):
 
     # Set default versions for browsers that don't have versions specified
     if browser and not version:
-        for browser_name in browser:
-            version.append("latest")
+        version = ["latest"] * len(browser)
 
     if os_name and not os_version:
-        for os in os_name:
-            if os.lower() in default_os_versions:
-                os_version.append(default_os_versions[os.lower()])
+        for os_entry in os_name:
+            if os_entry.lower() in default_os_versions:
+                os_version.append(default_os_versions[os_entry.lower()])
             else:
-                raise ValueError(f"No default version available for browser '{os}'. Please specify a version using --ver.")
+                raise ValueError(f"No default version available for browser '{os_entry}'. Please specify a version using --ver.")
 
 
     # Assign back the modified version list to config (in case it was updated)
-    config.option.browser_version = version    
+    config.option.browser_version = version
 
     global if_reportportal
     if_reportportal =config.getoption('--reportportal')


### PR DESCRIPTION
Have added link between CLI arguments that are required to run the test remotely.
- If you pass the browser version without setting the browser, the test will error out with the message asking you to set the browser
- If you pass the OS version without specifying the OS name then test will error out with message asking you to set the os name
- If you pass the browser and not specify the browser version then it will run against the latest version of that browser
- If you pass the OS name without specifying the version then, if the OS is windows it will run against "windows 11" , if its "os x" then it will run against "sequoia"