### PR TITLE
Added CLI option for element highlighter 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ from utils import interactive_mode
 load_dotenv()
 
 @pytest.fixture
-def test_obj(base_url, browser, browser_version, os_version, os_name, remote_flag, testrail_flag, tesults_flag, test_run_id, remote_project_name, remote_build_name, testname, reportportal_service, interactivemode_flag):
+def test_obj(base_url, browser, browser_version, os_version, os_name, remote_flag, testrail_flag, tesults_flag, test_run_id, remote_project_name, remote_build_name, testname, reportportal_service, interactivemode_flag, highlighter_flag):
     "Return an instance of Base Page that knows about the third party integrations"
     try:
         if interactivemode_flag.lower() == "y":
@@ -25,6 +25,10 @@ def test_obj(base_url, browser, browser_version, os_version, os_name, remote_fla
         test_obj.set_calling_module(testname)
         #Setup and register a driver
         test_obj.register_driver(remote_flag, os_name, os_version, browser, browser_version, remote_project_name, remote_build_name, testname)
+
+        #Set highlighter
+        if highlighter_flag.lower()=='y':
+            test_obj.turn_on_highlight()
 
         #Setup TestRail reporting
         if testrail_flag.lower()=='y':
@@ -260,6 +264,16 @@ def remote_flag(request):
     "pytest fixture for browserstack/sauce flag"
     try:
         return request.config.getoption("--remote_flag")
+
+    except Exception as e:
+        print("Exception when trying to run test: %s"%__file__)
+        print("Python says:%s"%str(e))
+
+@pytest.fixture
+def highlighter_flag(request):
+    "pytest fixture for element highlighter flag"
+    try:
+        return request.config.getoption("--highlighter_flag")
 
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
@@ -788,7 +802,6 @@ def pytest_addoption(parser):
                             dest="appium_version",
                             help="The appium version if its run in BrowserStack",
                             default="2.4.1")
-
         parser.addoption("--interactive_mode_flag",
                             dest="questionary",
                             default="n",
@@ -801,7 +814,10 @@ def pytest_addoption(parser):
                             dest="orientation",
                             default=None,
                             help="Enter LANDSCAPE to change device orientation to landscape")
-
+        parser.addoption("--highlighter_flag",
+                            dest="highlighter_flag",
+                            default='Y',
+                            help="Y or N. 'Y' if you want turn of element highlighter")
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))

--- a/conftest.py
+++ b/conftest.py
@@ -816,8 +816,8 @@ def pytest_addoption(parser):
                             help="Enter LANDSCAPE to change device orientation to landscape")
         parser.addoption("--highlighter_flag",
                             dest="highlighter_flag",
-                            default='Y',
-                            help="Y or N. 'Y' if you want turn of element highlighter")
+                            default='N',
+                            help="Y or N. 'Y' if you want turn on element highlighter")
     except Exception as e:
         print("Exception when trying to run test: %s"%__file__)
         print("Python says:%s"%str(e))

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -73,6 +73,7 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
         self.exceptions = []
         self.gif_file_name = None
         self.rp_logger = None
+        self.highlight_flag = False
 
     def switch_page(self,page_name):
         "Switch the underlying class to the required Page"
@@ -94,10 +95,6 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
     def turn_on_highlight(self):
         "Highlight the elements being operated upon"
         self.highlight_flag = True
-
-    def turn_off_highlight(self):
-        "Turn off the highlighting feature"
-        self.highlight_flag = False
 
     def set_calling_module(self,name):
         "Set the test name"

--- a/tests/test_example_form.py
+++ b/tests/test_example_form.py
@@ -26,10 +26,6 @@ def test_example_form(test_obj):
         #Set start_time with current time
         start_time = int(time.time())
 
-
-        # Turn on the highlighting feature
-        test_obj.turn_on_highlight()
-
         #4. Get the test details from the conf file
         name = conf.name
         email = conf.email
@@ -83,9 +79,6 @@ def test_example_form(test_obj):
                             level="critical")
         test_obj.add_tesults_case("Submit Form", "Submits the form", "test_example_form", result_flag,"Failed to submit the form \nOn url: %s"%test_obj.get_current_url(), [])
 
-        #Turn off the highlighting feature
-        test_obj.turn_off_highlight()
-
         #11. Check the heading on the redirect page
         #Notice you don't need to create a new page object!
         if result_flag is True:
@@ -95,9 +88,6 @@ def test_example_form(test_obj):
                             negative="Fail: Heading on the redirect page is incorrect!")
         test_obj.write('Script duration: %d seconds\n'%(int(time.time()-start_time)))
         test_obj.add_tesults_case("Check Heading", "Checks the heading on the redirect page", "test_example_form", result_flag,"Fail: Heading on the redirect page is incorrect!", [])
-
-         # Turn on the highlighting feature
-        test_obj.turn_on_highlight()
 
         #12. Visit the contact page and verify the link
         result_flag = test_obj.goto_footer_link('Contact > Get in touch!','contact')

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/weather-shopper-app-apk/app/
 
 #Command to run the test
-commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --highlighter_flag n --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/weather-shopper-app-apk/app/
 
 #Command to run the test
-commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --highlighter_flag n --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py


### PR DESCRIPTION
- Added CLI option `--highlighter_flag` to turn on and off element highlighter
- Updated test `test_example_form.py` file - removed previous way to turn on and off the highlighter
- By default set highlighter flag to true `--highlighter_flag Y`
- For CI run set highlighter flag to false `--highlighter_flag N`, it will further reduce our CI build run time

Command to run the test with highlighter:
`pytest -k example_form` or `pytest -k example_form --highlighter_flag Y`

Command to run test without highlighter:
`pytest -k example_form --highlighter_flag N`  