### PR TITLE
Skip weathershopper payment test and remove tesseract ocr in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,6 @@ jobs:
 
         - run: sudo apt-get update
 
-        - run: sudo apt-get install -y tesseract-ocr
-
         - run:
             name: Run Flask app in background
             command: |

--- a/tests/test_weather_shopper_payment_app.py
+++ b/tests/test_weather_shopper_payment_app.py
@@ -23,6 +23,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from page_objects.PageFactory import PageFactory
 import conf.weather_shopper_mobile_conf as conf
 
+pytest.skip("Skipping test as ocr fail in circleCI", allow_module_level=True)
 @pytest.mark.MOBILE
 def test_weather_shopper_payment_app(test_mobile_obj):
     "Run the test."


### PR DESCRIPTION
- Removed  ` - run: sudo apt-get install -y tesseract-ocr` from config.yml
- Marked pytest.skip() for 'test_weather_shopper_payment_app.py" test script.
https://trello.com/c/XRnVFJAG/9-remove-weathershopperpaymenttest-from-circle-ci-run