### PR TITLE
Print prettytable summary for failure

### DIFF
--- a/core_helpers/custom_pytest_plugins.py
+++ b/core_helpers/custom_pytest_plugins.py
@@ -1,0 +1,23 @@
+"""
+This module houses custom pytest plugins implemented
+Plugins added:
+- CustomTerminalReporter: Print a prettytable failure summary using pytest
+"""
+
+from _pytest.terminal import TerminalReporter
+from .prettytable_object import FailureSummaryTable # pylint: disable=relative-beyond-top-level
+
+class CustomTerminalReporter(TerminalReporter): # pylint: disable=subclassed-final-class
+    "A custom pytest TerminalReporter plugin"
+    def __init__(self, config):
+        self.failed_scenarios = {}
+        super().__init__(config)
+
+    # Overwrite the summary_failures method to print the prettytable summary
+    def summary_failures(self):
+        if self.failed_scenarios:
+            table = FailureSummaryTable()
+            # Print header
+            self.write_sep(sep="=", title="Failure Summary", red=True)
+            # Print table
+            table.print_table(self.failed_scenarios)

--- a/core_helpers/logging_objects.py
+++ b/core_helpers/logging_objects.py
@@ -20,12 +20,6 @@ class Logging_Objects:
         self.make_gif()
         if self.gif_file_name is not None:
             self.write("Screenshots & GIF created at %s"%self.screenshot_dir)
-            self.write('************************')
-        failure_message_list = self.get_failure_message_list()
-        if len(failure_message_list) > 0:
-            self.write('\n--------FAILURE SUMMARY--------\n',level="error")
-            for msg in failure_message_list:
-                self.write(msg,level="error")
         if len(self.exceptions) > 0:
             self.exceptions = list(set(self.exceptions))
             self.write('\n--------USEFUL EXCEPTION--------\n',level="critical")
@@ -54,6 +48,8 @@ class Logging_Objects:
         if level.lower() == "inverse":
             if flag is True:
                 self.failure(positive,level="error")
+                # Collect the failed scenarios for prettytable summary
+                self.failed_scenarios.append(positive)
             else:
                 self.success(negative,level="success")
         else:
@@ -61,6 +57,8 @@ class Logging_Objects:
                 self.success(positive,level="success")
             else:
                 self.failure(negative,level="error")
+                # Collect the failed scenarios for prettytable summary
+                self.failed_scenarios.append(negative)
 
     def get_failure_message_list(self):
         "Return the failure message list"

--- a/core_helpers/mobile_app_helper.py
+++ b/core_helpers/mobile_app_helper.py
@@ -58,6 +58,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
         self.mini_check_counter = 0 #Increment when conditional_write is called
         self.mini_check_pass_counter = 0 #Increment when conditional_write is called with True
         self.failure_message_list = []
+        self.failed_scenarios = [] # <- Collect failed scenarios for table summary
         self.rp_logger = None
         self.exceptions = []
         self.screenshot_counter = 1

--- a/core_helpers/prettytable_object.py
+++ b/core_helpers/prettytable_object.py
@@ -1,0 +1,42 @@
+"""
+A module to house prettytable custom objects
+This tail made objects are used by pytest to print table output of failure summary
+"""
+from prettytable.colortable import ColorTable, Theme, Themes
+
+#pylint: disable=too-few-public-methods
+class PrettyTableTheme(Themes):
+    "A custom color theme object"
+    Failure = Theme(default_color="31",
+                    vertical_color="31",
+                    horizontal_color="31",
+                    junction_color="31")
+
+class FailureSummaryTable():
+    "Failure Summary Table to be printed in the pytest result summary"
+    def __init__(self) -> None:
+        """
+        Initializer
+        """
+        # Create a pretty color table in red to mark failures
+        self.table = ColorTable(theme=PrettyTableTheme.Failure)
+        self.table.field_names = ["Tests Failed"]
+        self.table.align = "l" # <- Align the content of the table left
+
+    def print_table(self, testsummary: dict) -> None:
+        """
+        Print the Failure Summary table
+        :param:
+            :testsummary: A dict with testname as key and failed scenarios as a list
+        """
+        try:
+            for testname, testscenarios in testsummary.items():
+                self.table.add_row([f"{testname}:"])
+                for scenario in testscenarios:
+                    self.table.add_row([f"\u2717 {scenario}"]) # <- Add unicode x mark
+                self.table.add_row([""]) # Add a empty row for spacing after a testname
+            if testsummary:
+                print(self.table)
+        except Exception as err: # pylint: disable=broad-except
+            print("Unable to print prettytable failure summary")
+            raise err

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -69,6 +69,7 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
         self.mini_check_counter = 0 #Increment when conditional_write is called
         self.mini_check_pass_counter = 0 #Increment when conditional_write is called with True
         self.failure_message_list = []
+        self.failed_scenarios = [] # <- Collect the failed scenarios for prettytable summary
         self.screenshot_counter = 1
         self.exceptions = []
         self.gif_file_name = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ beautifulsoup4>=4.12.3
 openai==1.12.0
 pytesseract==0.3.10
 pytest-asyncio==0.23.7
+prettytable==3.10.2


### PR DESCRIPTION
Integrated `prettytable` failure summary to the framework as a `pytest` plugin. The `TerminalReporter` pytest plugin is overwritten with a `CustomTerminalReported` object to print the table summary. The `prettytable` is used only when there is a failure.

Changes tracked in the PR:
1. Created a `pytest` plugin to print the failures in a table using [prettytable](https://pypi.org/project/prettytable/)
2. Modified `conftest.py` file to get the failed scenarios from test objects and pass them on to the `testreporter` plugin
3. Added a  `integrations/reporting_tools/prettytable_object.py` module to configure the table used to print the test failure summary