### PR TITLE
Capturing core helpers exceptions under log file

### DIFF
--- a/core_helpers/mobile_app_helper.py
+++ b/core_helpers/mobile_app_helper.py
@@ -135,7 +135,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
                         result_flag = True
                         return result_flag
                 except Exception:
-                    self.write('Element not found, swiping again', 'debug')
+                    self.write('Element not found, swiping again', 'critical')
                     pass
 
                 # Perform swipe based on direction
@@ -150,7 +150,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             return result_flag
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append(f'Error while swiping to element - {search_element_locator}')
 
     def swipe_coordinates(self, scroll_group):
@@ -182,7 +182,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             return coordinates
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("Error while calculating swipe coordinates")
 
     def perform_swipe(self, direction, start_x, start_y, end_x, end_y, center_x, center_y, duration):
@@ -198,7 +198,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
                 self.driver.swipe(start_x=end_x, start_y=center_y, end_x=start_x, end_y=center_y, duration=duration)
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("Error while performing swipe")
 
     def zoom(self, element_locator, zoom_direction="in"):
@@ -225,7 +225,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
                 return False
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("An exception occurred when zooming")
 
     def perform_zoom(self, zoom_direction, center_x, center_y):
@@ -257,7 +257,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             actions.perform()
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occured when performing the zooming")
 
     def get_element_center(self, element):
@@ -279,7 +279,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             return coordinates
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occured when getting the element coordinates")
 
     def long_press(self, element, duration=5):
@@ -297,7 +297,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
 
         except Exception as e:
             # Log error if any exception occurs
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("Error while performing long press gesture.")
         return ressult_flag
 
@@ -329,7 +329,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             actions.perform()
 
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occured when performing drag and drop")
 
     def scroll_to_bottom(self, scroll_amount=10):
@@ -342,7 +342,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             value=f'new UiScrollable(new UiSelector().scrollable(true).instance(0)).flingToEnd({scroll_amount})')
             result_flag = True
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occurred when scrolling to the bottom of the page")
         return result_flag
 
@@ -356,7 +356,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             value=f'new UiScrollable(new UiSelector().scrollable(true).instance(0)).flingToBeginning({scroll_amount})')
             result_flag = True
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("An exception occured when scrolling to top of page")
         return result_flag
 
@@ -371,7 +371,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             )
             result_flag = True
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occurred when scrolling backward")
         return result_flag
 
@@ -386,7 +386,7 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             )
             result_flag = True
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occurred when scrolling forward")
         return result_flag
 
@@ -400,5 +400,5 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             source = self.driver.page_source
             return source
         except Exception as e:
-            self.write(str(e), 'debug')
+            self.write(str(e), 'critical')
             self.exceptions.append("An exception occured when getting source")

--- a/core_helpers/screenshot_objects.py
+++ b/core_helpers/screenshot_objects.py
@@ -42,8 +42,8 @@ class Screenshot_Objects:
                 },
             )
         except Exception as e:
-            self.write("Exception when trying to get rplogger")
-            self.write(str(e))
+            self.write("Exception when trying to get rplogger",'critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when trying to get reportportal logger")
 
     def make_gif(self):
@@ -88,7 +88,7 @@ class Screenshot_Objects:
                 try:
                     shutil.rmtree(self.screenshot_dir)
                 except OSError as e:
-                    self.write("Error: %s - %s." % (e.filename, e.strerror))
+                    self.write("Error: %s - %s." % (e.filename, e.strerror),'critical')
         return self.screenshot_dir
 
     def create_screenshot_dir(self, screenshot_dir):
@@ -98,6 +98,6 @@ class Screenshot_Objects:
                 os.makedirs(screenshot_dir)
             return screenshot_dir
         except Exception as e:
-            self.write("Exception when trying to set screenshot directory")
-            self.write(str(e))
+            self.write("Exception when trying to set screenshot directory",'critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when setting up the screenshot directory")

--- a/core_helpers/selenium_action_objects.py
+++ b/core_helpers/selenium_action_objects.py
@@ -275,7 +275,7 @@ class Selenium_Action_Objects:
             result_flag = True  # Update the result flag to True if hover is successful
         except Exception as e:
             self.write(str(e),'critical')
-            self.exceptions.append("An exception occured when hovering over the element", locator)
+            self.exceptions.append(f"An exception occured when hovering over the element - {locator}")
         return result_flag
 
     def drag_and_drop(self, source_locator, target_locator):
@@ -290,7 +290,7 @@ class Selenium_Action_Objects:
             result_flag = True
         except Exception as e:
             self.write(str(e),'critical')
-            self.exceptions.append(f"An error occurred during drag and drop action.")
+            self.exceptions.append(f"An error occurred during drag and drop action.{str(e)}")
 
         return result_flag
 

--- a/core_helpers/selenium_action_objects.py
+++ b/core_helpers/selenium_action_objects.py
@@ -27,7 +27,7 @@ class Selenium_Action_Objects:
                 self.highlight_element(dom_element)
         except Exception as e:
             if verbose_flag is True:
-                self.write(str(e),'debug')
+                self.write(str(e),'critical')
                 self.write("Check your locator-'%s,%s' in the conf/locators.conf file" %(locator[0],locator[1]))
             self.exceptions.append("Check your locator-'%s,%s' in the conf/locators.conf file" %(locator[0],locator[1]))
 
@@ -43,7 +43,7 @@ class Selenium_Action_Objects:
                 self.highlight_elements(dom_elements)
         except Exception as e:
             if msg_flag==True:
-                self.write(str(e),'debug')
+                self.write(str(e),'critical')
                 self.write("Check your locator-'%s,%s' in the conf/locators.conf file" %(locator[0],locator[1]))
             self.exceptions.append("Unable to locate the element with the xpath -'%s,%s' in the conf/locators.conf file"%(locator[0],locator[1]))
 
@@ -59,7 +59,7 @@ class Selenium_Action_Objects:
         try:
             result = tuple(locator.split(',',1))
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.write("Error while parsing locator")
             self.exceptions.append("Unable to split the locator-'%s,%s' in the conf/locators.conf file"%(locator[0],locator[1]))
 
@@ -96,7 +96,7 @@ class Selenium_Action_Objects:
                 result_flag=True
                 self.wait(wait_time)
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.write('Exception when clicking link with path: %s'%locator)
             self.exceptions.append("Error when clicking the element with path,'%s' in the conf/locators.conf file"%locator)
 
@@ -111,10 +111,10 @@ class Selenium_Action_Objects:
                 try:
                     text_field.clear()
                 except Exception as e:
-                    self.write(str(e),'debug')
+                    self.write(str(e),'critical')
                     self.exceptions.append("Could not clear the text field- '%s' in the conf/locators.conf file"%locator)
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("Check your locator-'%s,%s' in the conf/locators.conf file" %(locator[0],locator[1]))
 
         result_flag = False
@@ -123,8 +123,8 @@ class Selenium_Action_Objects:
                 text_field.send_keys(value)
                 result_flag = True
             except Exception as e:
-                self.write('Could not write to text field: %s'%locator,'debug')
-                self.write(str(e),'debug')
+                self.write('Could not write to text field: %s'%locator,'critical')
+                self.write(str(e),'critical')
                 self.exceptions.append("Could not write to text field- '%s' in the conf/locators.conf file"%locator)
 
         return result_flag
@@ -138,7 +138,7 @@ class Selenium_Action_Objects:
             else:
                 text = locator.text
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when getting text from the path-'%s' in the conf/locators.conf file"%locator)
             return None
         else:
@@ -154,7 +154,7 @@ class Selenium_Action_Objects:
             text = dom_element.text
             text = text.encode('utf-8')
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when getting text from the DOM element-'%s' in the conf/locators.conf file"%dom_element)
 
         return text
@@ -169,7 +169,7 @@ class Selenium_Action_Objects:
             else:
                 result_flag = True
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when selecting checkbox-'%s' in the conf/locators.conf file"%locator)
 
         return result_flag
@@ -184,7 +184,7 @@ class Selenium_Action_Objects:
             else:
                 result_flag = True
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when deselecting checkbox-'%s' in the conf/locators.conf file"%locator)
 
         return result_flag
@@ -196,7 +196,7 @@ class Selenium_Action_Objects:
         try:
             return self.click_element(locator)
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when toggling checkbox-'%s' in the conf/locators.conf file"%locator)
 
 
@@ -211,7 +211,7 @@ class Selenium_Action_Objects:
                     result_flag = True
                     break
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Error when selecting option from the drop-down '%s' "%locator)
 
         return result_flag
@@ -234,7 +234,7 @@ class Selenium_Action_Objects:
                 if element.is_displayed() is True:
                     result_flag = True
         except Exception as e:
-            self.write(e)
+            self.write(str(e),'critical')
             self.exceptions.append("Web element not present in the page, please check the locator is correct -'%s' in the conf/locators.conf file"%locator)
 
         return result_flag
@@ -246,7 +246,7 @@ class Selenium_Action_Objects:
             element.send_keys(Keys.ENTER)
             self.wait(wait_time)
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("An exception occurred when hitting enter")
             return None
 
@@ -260,7 +260,7 @@ class Selenium_Action_Objects:
             self.wait(wait_time)
             result_flag = True
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("An exception occured when scrolling down")
         return result_flag
 
@@ -274,7 +274,7 @@ class Selenium_Action_Objects:
             self.wait(wait_seconds)
             result_flag = True  # Update the result flag to True if hover is successful
         except Exception as e:
-            self.write(str(e),'debug')
+            self.write(str(e),'critical')
             self.exceptions.append("An exception occured when hovering over the element", locator)
         return result_flag
 
@@ -289,7 +289,8 @@ class Selenium_Action_Objects:
             action_obj.drag_and_drop(source_element, target_element).perform()
             result_flag = True
         except Exception as e:
-            print(f"An error occurred: {str(e)}")
+            self.write(str(e),'critical')
+            self.exceptions.append(f"An error occurred during drag and drop action.")
 
         return result_flag
 
@@ -305,7 +306,8 @@ class Selenium_Action_Objects:
             self.driver.hide_keyboard()
             result_flag=True
         except Exception as e:
-            print(f"An error occured during keyboard minimise: {str(e)}")
+            self.write(str(e),'critical')
+            self.exceptions.append(f"An error occured during keyboard minimise: {str(e)}")
 
         return result_flag
 
@@ -315,7 +317,8 @@ class Selenium_Action_Objects:
             self.driver.execute_script(js_script)
             result_flag = True
         except Exception as e:
-            print(f"An error occured during javascript execution: {str(e)}")
+            self.write(str(e),'critical')
+            self.exceptions.append(f"An error occured during javascript execution: {str(e)}")
             result_flag = False
 
         return result_flag

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -170,8 +170,8 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             window_handle = self.get_current_window_handle()
             self.window_structure[window_handle] = name
         except Exception as e:
-            self.write("Exception when trying to set windows name")
-            self.write(str(e))
+            self.write("Exception when trying to set windows name",'critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when setting up the name of the current window")
 
     def get_window_by_name(self,window_name):
@@ -202,8 +202,8 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
                                 'Unable to locate and switch to the window with name: %s'%name,
                                 level='debug')
         except Exception as e:
-            self.write("Exception when trying to switch window")
-            self.write(str(e))
+            self.write("Exception when trying to switch window",'critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when switching browser window")
 
         return result_flag
@@ -218,8 +218,8 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             if (before_window_count - after_window_count) == 1:
                 result_flag = True
         except Exception as e:
-            self.write('Could not close the current window')
-            self.write(str(e))
+            self.write('Could not close the current window','critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when trying to close the current window")
 
         return result_flag
@@ -241,8 +241,8 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             result_flag = True
 
         except Exception as e:
-            self.write("Exception when trying to switch frame")
-            self.write(str(e))
+            self.write("Exception when trying to switch frame",'critical')
+            self.write(str(e),'critical')
             self.exceptions.append("Error when switching to frame")
 
         return result_flag
@@ -280,14 +280,14 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
         try:
             return self.axe_util.inject()
         except Exception as e:
-             self.write(e)
+             self.write(str(e),'critical')
 
     def accessibility_run_axe(self):
         "Run Axe into the Page"
         try:
             return self.axe_util.run()
         except Exception as e:
-             self.write(e)
+             self.write(str(e),'critical')
 
     def snapshot_assert_match(self, value, snapshot_name):
         "Asserts the current value of the snapshot with the given snapshot_name"
@@ -296,7 +296,7 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             self.snapshot_util.assert_match(value, snapshot_name)
             result_flag = True
         except Exception as e:
-             self.write(e)
+             self.write(str(e),'critical')
 
         return result_flag
 
@@ -307,8 +307,8 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             log = self.driver.get_log('browser')
             return log
         except Exception as e:
-            self.write("Exception when reading Browser Console log")
-            self.write(str(e))
+            self.write("Exception when reading Browser Console log",'critical')
+            self.write(str(e),'critical')
             return log
 
     def conditional_write(self,flag,positive,negative,level='info'):


### PR DESCRIPTION
- Capturing core helpers exceptions under log file - replaced `print` statements with our `write` method and appending it to our exceptions list.  
- set exceptions log level to critical.