### PR TITLE
Fixed issue ModuleNotFoundError: No module named 'distutils' when running tests in Python 3.12.3 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ openai==1.12.0
 pytesseract==0.3.10
 pytest-asyncio==0.23.7
 prettytable==3.10.2
+setuptools>=75.1.0; python_version >= '3.12'


### PR DESCRIPTION
Error `ModuleNotFoundError: No module named 'distutils'` occurs because `distutils` is no longer included by default in Python 3.12. I am able to reproduce the issue.

To fix the issue, added conditional setuptools installation for Python 3.12+ under requirements.txt file. After installation of setup tools, issue got fixed and able to run tests without any issue.