### PR TITLE
Fixed error running interactive mode for API tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -234,7 +234,7 @@ def test_api_obj(interactivemode_flag, testname, api_url=base_url_conf.api_base_
     log_file = testname + '.log'
     try:
         if interactivemode_flag.lower()=='y':
-            api_url,session_flag = interactive_mode.ask_questions_api(api_url)
+            api_url = interactive_mode.ask_questions_api(api_url)
             test_api_obj = APIPlayer(api_url,                                         # pylint: disable=redefined-outer-name
                                       log_file_path=log_file)
         else:

--- a/utils/interactive_mode.py
+++ b/utils/interactive_mode.py
@@ -254,9 +254,10 @@ def ask_questions_api(api_url):
 def get_user_response_api():
     "Get response from user for api tests"
     response=questionary.select("What would you like to change",
-                                 choices=["API URL","Session flag status",
+                                 choices=["API URL",
                                           "Reset back to default settings",
-                                          "Run","Exit"]).ask()
+                                          "Run",
+                                          "Exit"]).ask()
 
     return response
 


### PR DESCRIPTION
Fixed running tests in `interactive mode` for `API` tests