### PR TITLE
Fixed issue related to `api_url` cli option usage

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -229,7 +229,7 @@ def test_mobile_obj(mobile_os_name, mobile_os_version, device_name, app_package,
                             {"status":"failed", "reason": "Exception occured"}}""")
 
 @pytest.fixture
-def test_api_obj(interactivemode_flag, testname, api_url=base_url_conf.api_base_url):  # pylint: disable=redefined-outer-name
+def test_api_obj(interactivemode_flag, testname, api_url):  # pylint: disable=redefined-outer-name
     "Return an instance of Base Page that knows about the third party integrations"
     log_file = testname + '.log'
     try:
@@ -692,8 +692,8 @@ def pytest_addoption(parser):
                             default=base_url_conf.ui_base_url,
                             help="The url of the application")
         parser.addoption("--api_url",
-                            dest="url",
-                            default="https://cars-app.qxf2.com/",
+                            dest="api_url",
+                            default=base_url_conf.api_base_url,
                             help="The url of the api")
         parser.addoption("--testrail_flag",
                             dest="testrail_flag",


### PR DESCRIPTION
Fixed issue https://github.com/qxf2/qxf2-page-object-model/issues/481

Now, API tests using  `api_url` cli option value provided along with test run command.

Run API tests along with `api_url` cli option
`pytest tests/test_api_example.py  --api_url http://127.0.0.1:5000`

You can deploy cars app locally and run against it to confirm tests using api_url value passed with test run command.
