### PR TITLE
Qxf2 POM essentials dockerfile  

### DIFF
--- a/utils/qxf2_pom_essentials_dockerfiles/Readme.md
+++ b/utils/qxf2_pom_essentials_dockerfiles/Readme.md
@@ -1,0 +1,66 @@
+# 🐳 Qxf2 Page Object Model (POM) Docker Setup with VNC Access
+
+This Docker image sets up a Selenium testing environment with:
+
+- Google Chrome
+- Firefox
+- XVFB (virtual display)
+- x11vnc (VNC access to the GUI)
+- Python 3.12 and virtual environment
+- Sample tests to run selenium tests on Chrome and Firefox 
+
+## Prerequisites
+
+- Docker installed
+- A VNC Viewer (e.g., TigerVNC, RealVNC, Remmina)
+
+---
+
+## Build the Docker Image
+
+Run the following command in the directory where your `Dockerfile` is located:
+
+```
+docker build -t qxf2-pom-essentials:python3.12 .
+```
+---
+
+## Pull image from Docker Hub:
+You can also skip the build step and pull the pre-built image directly:
+```
+docker pull qxf2rohand/qxf2-pom-essentials:python3.12
+```
+View image at  https://hub.docker.com/r/qxf2rohand/qxf2_pom_essentials
+
+---
+##  Run the Docker Container
+```
+docker run -it -p 5999:5999 qxf2-pom-essentials:python3.12 /bin/bash
+```
+Port 5999 exposed for VNC access.
+
+---
+
+##  Connect via VNC
+1. Open your VNC Viewer
+
+2. Connect to:
+```vncviewer localhost:99```
+
+You’ll now see the browser UI inside your container.
+
+---
+
+## Run the Sample Test
+Inside the Docker container terminal:
+```
+python sample_test_chrome.py
+```
+You’ll now see VNC viewer, it opens the chrome browser and navigates to https://www.qxf2.com and prints title.
+
+---
+
+## Note:
+You can connect complete framework as a volume to container, install requirements, edit and run your tests.
+
+---

--- a/utils/qxf2_pom_essentials_dockerfiles/dockerfile
+++ b/utils/qxf2_pom_essentials_dockerfiles/dockerfile
@@ -1,0 +1,52 @@
+# Use the latest Ubuntu version explicitly (current version 24.04)
+FROM ubuntu:latest      
+LABEL maintainer="Qxf2 Services"
+
+# Set non-interactive mode for apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update package lists and install required dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    unzip \
+    xvfb \
+    x11vnc \
+    x11-xkb-utils \
+    xkb-data \
+    python3.12 \
+    python3.12-venv \
+    python3.12-dev \
+    python3-pip \
+    vim-tiny \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Google Chrome and Firefox(latest stable)
+RUN wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && apt-get update \
+    && apt-get install -y /tmp/google-chrome.deb \
+    && rm /tmp/google-chrome.deb \
+    && apt-get update && apt-get install -y firefox \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a virtual environment and install Selenium (as the non-root user)
+RUN python3 -m venv /home/venv \
+    && /home/venv/bin/pip install --no-cache-dir selenium
+
+# Set environment variables
+ENV PATH="/home/venv/bin:$PATH"
+ENV DISPLAY=:99
+
+# Add files to qxf2_pom directory
+ADD . /qxf2_pom
+
+# Set working directory
+WORKDIR /qxf2_pom
+
+#Expose port for VNC
+EXPOSE 5999
+
+# Make entrypoint.sh executable and set it to run at start
+RUN chmod +x /qxf2_pom/entrypoint.sh
+ENTRYPOINT ["/qxf2_pom/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/utils/qxf2_pom_essentials_dockerfiles/entrypoint.sh
+++ b/utils/qxf2_pom_essentials_dockerfiles/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export DISPLAY=:99
+Xvfb :99 -screen 0 1366x768x16 2>/dev/null &
+
+# Start x11vnc
+x11vnc -display :99 -forever -nopw -quiet -rfbport 5999 &
+
+# Run CMD command
+exec "$@"

--- a/utils/qxf2_pom_essentials_dockerfiles/sample_test_chrome.py
+++ b/utils/qxf2_pom_essentials_dockerfiles/sample_test_chrome.py
@@ -1,0 +1,10 @@
+from selenium import webdriver
+
+options = webdriver.ChromeOptions()
+options.add_argument("--no-sandbox") # Often needed in Docker/headless environments
+options.add_argument("--disable-dev-shm-usage")
+#options.add_argument("--headless") # Don't set it if you want to see test running on VNC Viewer
+driver = webdriver.Chrome(options=options)
+driver.get("http://www.qxf2.com")
+print(driver.title)
+driver.quit()

--- a/utils/qxf2_pom_essentials_dockerfiles/sample_test_ff.py
+++ b/utils/qxf2_pom_essentials_dockerfiles/sample_test_ff.py
@@ -1,5 +1,5 @@
 from selenium import webdriver
- 
+
 driver = webdriver.Firefox()
 driver.get("http://www.qxf2.com")
 print(driver.title)

--- a/utils/qxf2_pom_essentials_dockerfiles/sample_test_ff.py
+++ b/utils/qxf2_pom_essentials_dockerfiles/sample_test_ff.py
@@ -1,0 +1,6 @@
+from selenium import webdriver
+ 
+driver = webdriver.Firefox()
+driver.get("http://www.qxf2.com")
+print(driver.title)
+driver.quit()


### PR DESCRIPTION
- Added Qxf2 POM essentials dockerfile and other supporting files
- Build the image with python3.12 tag, tested it with sample test files and pushed it on Dockerhub. View image at https://hub.docker.com/r/qxf2rohand/qxf2_pom_essentials 
