### PR TITLE
Adding a safety net for get_current_url failure for weather shopper test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
         - run:
             name: Run different Tox environments on different Containers
             command: |
-               if [ $CIRCLE_NODE_INDEX == "0" ] ; then tox -e py39 ; fi
-               if [ $CIRCLE_NODE_INDEX == "1" ] ; then tox -e py310 ; fi
-               if [ $CIRCLE_NODE_INDEX == "2" ] ; then tox -e py311 ; fi
+               if [ $CIRCLE_NODE_INDEX == "0" ] ; then tox -e py311 ; fi
+               if [ $CIRCLE_NODE_INDEX == "1" ] ; then tox -e py312 ; fi
+               if [ $CIRCLE_NODE_INDEX == "2" ] ; then tox -e py313 ; fi
 
         - store_artifacts:
             path: ./screenshots

--- a/page_objects/examples/weather_shopper_mobile_app/webview_chrome.py
+++ b/page_objects/examples/weather_shopper_mobile_app/webview_chrome.py
@@ -22,6 +22,15 @@ class WebviewChrome(Mobile_App_Helper):
     @Wrapit._screenshot
     def get_current_url(self):
         "This method gets the current URL"
+        if len(self.driver.window_handles) > 1:
+            self.write("Multiple window handles detected", 'debug')
+            for handle in self.driver.window_handles:
+                self.driver.switch_to.window(handle)
+                if self.driver.current_url == "chrome-native://newtab/":
+                    self.write("Current URL is a new tab, switching to next handle", 'debug')
+                    continue
+                else:
+                    break
         url = unquote(self.driver.current_url)
         return url
 


### PR DESCRIPTION
Adding a safety net for get_current_url failure for weather shopper test
Also updating Python version to recent versions for tox run