### PR TITLE
Extended framework capability to automate windows desktop app

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 ![Codacy Badge](https://app.codacy.com/project/badge/Grade/c330930eaad64b9cabb62fee2a84fe69)
 
 --------
-A Pythonic Selenium, Appium and API test automation framework
+A Pythonic Selenium, Appium(Mobile & Windows) and API test automation framework
 --------
 You can use this test automation framework to write
 
@@ -18,7 +18,9 @@ You can use this test automation framework to write
 
 2. __Appium__ and Python scripts for __mobile automation__ (Android and iOS)
 
-3. __API automation__ scripts to test endpoints of your web/mobile applications
+3. __Appium , WinAppDriver__ and Python scripts for __windows automation__
+
+3. __API automation__ scripts to test endpoints of your web/mobile/desktop applications
 
 &nbsp;
 
@@ -46,6 +48,7 @@ The setup has four parts:
 2. [Setup for GUI/Selenium automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#2-setup-for-guiselenium-automation)
 3. [Setup for Mobile/Appium automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#3-setup-for-mobileappium-automation)
 4. [Setup for API automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#4-setup-for-api-automation)
+5. [Setup for Windows Automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#5-setup-for-windows-automation)
 
 Above links redirects to our github wiki pages.
 

--- a/conf/locators_conf.py
+++ b/conf/locators_conf.py
@@ -84,7 +84,6 @@ pay_button = "id,pay_button"
 payment_success = "xpath,//android.widget.TextView[@text='Payment Successful']"
 image_of_moisturizer = "xpath,//android.widget.TextView[@text='Wilhelm Aloe Hydration Lotion']/parent::*/android.widget.ImageView"
 image_of_sunscreen = "xpath,//android.widget.TextView[@text='Robert Herbals Sunblock SPF-40']/parent::*/android.widget.ImageView"
-
 menu_option = "xpath,//android.widget.ImageView[@content-desc='More options']"
 developed_by = "xpath,//android.widget.TextView[@text='Developed by Qxf2 Services']"
 about_app = "xpath,//android.widget.TextView[@text='About This App']"
@@ -93,7 +92,19 @@ privacy_policy = "xpath,//android.widget.TextView[@text='Privacy Policy']"
 contact_us = "xpath,//android.widget.TextView[@text='Contact us']"
 chrome_welcome_dismiss = "xpath,//android.widget.Button[@resource-id='com.android.chrome:id/signin_fre_dismiss_button']"
 turn_off_sync_button = "xpath,//android.widget.Button[@resource-id='com.android.chrome:id/negative_button']"
-
-
 image_of_moisturizer = "xpath,//android.widget.TextView[@text='Wilhelm Aloe Hydration Lotion']/parent::*/android.widget.ImageView"
 image_of_sunscreen = "xpath,//android.widget.TextView[@text='Robert Herbals Sunblock SPF-40']/parent::*/android.widget.ImageView"
+
+#Notepad
+notepad_textarea = "name,Text editor"
+file_menu = "accessibility id,File"
+
+#Word
+blank_document = "name,Blank document"
+click_word_textarea = "xpath,//Custom/Edit"
+word_textarea = "xpath,//Document"
+insert_tab = "accessibility id,TabInsert"
+icon_button = "accessibility id,IconInsertFromFile"
+stock_image_popup_window = "accessibility id,Pivot7-Tab1"
+icon_angel_face = "accessibility id,Icons_AngelFace"
+insert_icons_button = "name,Insert (1)"

--- a/conftest.py
+++ b/conftest.py
@@ -252,6 +252,89 @@ def test_api_obj(interactivemode_flag, testname, api_url):  # pylint: disable=re
         print(Logging_Objects.color_text(f"Exception when trying to run test:{__file__}","red"))
         print(Logging_Objects.color_text(f"Python says:{str(e)}","red"))
 
+
+@pytest.fixture
+def test_windows_obj(remote_flag, testrail_flag, tesults_flag, test_run_id, appium_server_address,   # pylint: disable=redefined-outer-name
+                    win_app_full_path, testname, testreporter):                # pylint: disable=redefined-outer-name
+    "Return an instance of Base Page that knows about the third party integrations"
+    try:
+        test_windows_obj = PageFactory.get_page_object("Zero mobile")  # pylint: disable=redefined-outer-name
+        test_windows_obj.set_calling_module(testname)
+        #Setup and register a driver
+        test_windows_obj.register_windows_driver(appium_server_address,win_app_full_path)
+
+        #3. Setup TestRail reporting
+        if testrail_flag.lower()=='y':
+            if test_run_id is None:
+                test_windows_obj.write("\n\nTestRail Integration Exception: "\
+                    "It looks like you are trying to use TestRail Integration "\
+                    "without providing test run id. \nPlease provide a valid test run id "\
+                    "along with test run command using --test_run_id and try again."\
+                    " for eg: pytest --testrail_flag Y --test_run_id 100\n",level='critical')
+                testrail_flag = 'N'
+            if test_run_id is not None:
+                test_windows_obj.register_testrail()
+                test_windows_obj.set_test_run_id(test_run_id)
+
+        if tesults_flag.lower()=='y':
+            test_windows_obj.register_tesults()
+
+        yield test_windows_obj
+
+        # Collect the failed scenarios, these scenarios will be printed as table \
+        # by the pytest's custom testreporter
+        if test_windows_obj.failed_scenarios:
+            testreporter.failed_scenarios[testname] = test_windows_obj.failed_scenarios
+
+        if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
+            response = upload_test_logs_to_browserstack(test_windows_obj.log_name,
+                                                        test_windows_obj.session_url,
+                                                        appium_test = True)
+            if isinstance(response, dict) and "error" in response:
+                # Handle the error response returned as a dictionary
+                test_windows_obj.write(f"Error: {response['error']}",level='error')
+                if "details" in response:
+                    test_windows_obj.write(f"Details: {response['details']}",level='error')
+                    test_windows_obj.write("Failed to upload log file to BrowserStack",level='error')
+            else:
+                # Handle the case where the response is assumed to be a response object
+                if response.status_code == 200:
+                    test_windows_obj.write("Log file uploaded to BrowserStack session successfully.",
+                                            level='success')
+                else:
+                    test_windows_obj.write("Failed to upload log file. "\
+                                            f"Status code: {response.status_code}",level='error')
+                    test_windows_obj.write(response.text,level='error')
+            #Update test run status to respective BrowserStack session
+            if test_windows_obj.pass_counter == test_windows_obj.result_counter:
+                test_windows_obj.write("Test Status: PASS",level='success')
+                result_flag = test_windows_obj.execute_javascript("""browserstack_executor:
+                                {"action": "setSessionStatus", "arguments": {"status":"passed",
+                                "reason": "All test cases passed"}}""")
+                test_windows_obj.conditional_write(result_flag,
+                            positive="Successfully set BrowserStack Test Session Status to PASS",
+                            negative="Failed to set Browserstack session status to PASS")
+            else:
+                test_windows_obj.write("Test Status: FAILED",level='error')
+                result_flag = test_windows_obj.execute_javascript("""browserstack_executor:
+                            {"action": "setSessionStatus", "arguments": {"status":"failed",
+                            "reason": "Test failed. Look at terminal logs for more details"}}""")
+                test_windows_obj.conditional_write(result_flag,
+                            positive="Successfully set BrowserStack Test Session Status to FAILED",
+                            negative="Failed to set Browserstack session status to FAILED")
+            test_windows_obj.write("*************************")
+        #Teardown
+        test_windows_obj.wait(3)
+        test_windows_obj.teardown()
+
+    except Exception as e:                      # pylint: disable=broad-exception-caught
+        print(Logging_Objects.color_text(f"Exception when trying to run test:{__file__}","red"))
+        print(Logging_Objects.color_text(f"Python says:{str(e)}","red"))
+        if os.getenv('REMOTE_BROWSER_PLATFORM') == 'BS' and remote_flag.lower() == 'y':
+            test_windows_obj.execute_javascript("""browserstack_executor:
+                            {"action": "setSessionStatus", "arguments":
+                            {"status":"failed", "reason": "Exception occured"}}""")
+
 # Fixtures for API Endpoint Auto generation unit tests
 @pytest.fixture
 def name_generator():
@@ -456,6 +539,16 @@ def no_reset_flag(request):
 def app_path(request):
     "pytest fixture for app path"
     return request.config.getoption("--app_path")
+
+@pytest.fixture
+def appium_server_address(request):
+    "pytest fixture for app path"
+    return request.config.getoption("--appium_server_address")
+
+@pytest.fixture
+def win_app_full_path(request):
+    "pytest fixture for app path"
+    return request.config.getoption("--win_app_full_path")
 
 @pytest.fixture
 def interactivemode_flag(request):
@@ -824,6 +917,15 @@ def pytest_addoption(parser):
                             dest="appium_version",
                             help="The appium version if its run in BrowserStack",
                             default="2.4.1")
+        parser.addoption("--appium_server_address",
+                            dest="appium_server_address",
+                            help="appium server host address",
+                            default="http://127.0.0.1:4723")
+        parser.addoption("--win_app_full_path",
+                            dest="win_app_full_path",
+                            help=("Windows app full path along with app file name. "
+                            r"Ex. C:\Windows\System32\notepad.exe"),
+                            default=r"C:\Program Files\Microsoft Office\root\Office16\WINWORD.exe")
         parser.addoption("--interactive_mode_flag",
                             dest="questionary",
                             default="n",

--- a/core_helpers/drivers/driverfactory.py
+++ b/core_helpers/drivers/driverfactory.py
@@ -171,6 +171,18 @@ class DriverFactory(RemoteOptions, LocalOptions):
 
         return mobile_driver,session_url
 
+    def get_windows_driver(self, appium_server_address, win_app_full_path):
+        "return windows driver"
+        from appium import webdriver
+        session_url = None
+        options = self.set_windows_device(win_app_full_path)
+        driver = webdriver.Remote(
+                    command_executor= appium_server_address,
+                    options=options
+                )
+
+        return driver,session_url
+
     @staticmethod
     def print_exception(exception, remote_flag):
         """Print out the exception message and suggest the solution based on the remote flag."""

--- a/core_helpers/drivers/local_options.py
+++ b/core_helpers/drivers/local_options.py
@@ -90,3 +90,13 @@ class LocalOptions():
         desired_capabilities['orientation'] = orientation
 
         return desired_capabilities
+
+    def set_windows_device(self,win_app_full_path):
+        "set windows capabilities"
+        from appium.options.windows import WindowsOptions
+        options = WindowsOptions()
+        options.platform_name = "Windows"
+        options.app = win_app_full_path
+        options.automation_name = "Windows"
+
+        return options

--- a/core_helpers/mobile_app_helper.py
+++ b/core_helpers/mobile_app_helper.py
@@ -79,6 +79,15 @@ class Mobile_App_Helper(Borg,unittest.TestCase, Selenium_Action_Objects, Logging
             self.write( "Cloud Session URL for test: " + self.calling_module + '\n' + str(self.session_url))
         self.start()
 
+    def register_windows_driver(self,appium_server_address, win_app_full_path):
+        "Register windows driver"
+        self.driver,self.session_url = self.driver_obj.get_windows_driver(appium_server_address, win_app_full_path)
+        self.set_screenshot_dir() # Create screenshot directory
+        self.set_log_file()
+        if self.session_url:
+            self.write( "Cloud Session URL for test: " + self.calling_module + '\n' + str(self.session_url))
+        self.start()
+
     def get_driver_title(self):
         "Return the title of the current page"
         return self.driver.title

--- a/core_helpers/selenium_action_objects.py
+++ b/core_helpers/selenium_action_objects.py
@@ -250,6 +250,68 @@ class Selenium_Action_Objects:
             self.exceptions.append("An exception occurred when hitting enter")
             return None
 
+    def send_keys_to_element(self, locator, keys, wait_time=2):
+        """
+        Send any keys or key combinations to an element.
+        Supports formats like:
+        ('CONTROL', 'a')
+        ('SHIFT', 'TAB')
+        ['CONTROL', 'a']
+        'Hello'
+        'DELETE'
+        Returns True/False.
+        """
+        # Mapping string names to Selenium key constants
+        key_map = {
+            "CONTROL": Keys.CONTROL,
+            "SHIFT": Keys.SHIFT,
+            "ALT": Keys.ALT,
+            "ENTER": Keys.ENTER,
+            "RETURN": Keys.RETURN,
+            "TAB": Keys.TAB,
+            "DELETE": Keys.DELETE,
+            "BACKSPACE": Keys.BACKSPACE,
+            "ESC": Keys.ESCAPE,
+            "SPACE": Keys.SPACE,
+        }
+
+        # Converts string key names to actual Selenium key constants
+        def convert_key(key_name):
+            return key_map.get(key_name, key_name)
+
+        result_flag = False
+
+        try:
+            element = self.get_element(locator)
+
+            # Case 1: List of key sequences
+            if isinstance(keys, list):
+                for key_sequence in keys:
+                    if isinstance(key_sequence, tuple):
+                        converted_keys = [convert_key(item) for item in key_sequence]
+                        element.send_keys(*converted_keys)
+                    else:
+                        element.send_keys(convert_key(key_sequence))
+
+            # Case 2: Single key sequence
+            else:
+                if isinstance(keys, tuple):
+                    converted_keys = [convert_key(item) for item in keys]
+                    element.send_keys(*converted_keys)
+                else:
+                    element.send_keys(convert_key(keys))
+
+            self.wait(wait_time)
+            result_flag = True
+
+        except Exception as e:
+            self.write(str(e), "critical")
+            self.exceptions.append("An exception occurred when sending keys")
+            result_flag = False
+
+        return result_flag
+
+
     def scroll_down(self,locator,wait_time=2):
         "Scroll down"
         result_flag=False

--- a/page_objects/PageFactory.py
+++ b/page_objects/PageFactory.py
@@ -56,4 +56,10 @@ class PageFactory():
         elif page_name == "webview":
             from page_objects.examples.weather_shopper_mobile_app.webview_chrome import WebviewChrome
             test_obj = WebviewChrome()
+        elif page_name == "word":
+            from page_objects.examples.windows_word_app.word_home_page import WordHomePage
+            test_obj = WordHomePage()
+        elif page_name == "notepad":
+            from page_objects.examples.windows_notepad_app.notepad_home_page import NotepadHomePage
+            test_obj = NotepadHomePage()
         return test_obj

--- a/page_objects/examples/windows_notepad_app/notepad_home_page.py
+++ b/page_objects/examples/windows_notepad_app/notepad_home_page.py
@@ -1,0 +1,106 @@
+"""
+This class models the home page in notepad application.
+"""
+# pylint: disable = W0212,E0401
+from core_helpers.mobile_app_helper import Mobile_App_Helper
+import conf.locators_conf as locators
+from utils.Wrapit import Wrapit
+
+class NotepadHomePage(Mobile_App_Helper):
+    "Page objects for home page in Weathershopper application."
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def clear_text_if_any(self):
+        "Send Ctrl + A and Delete to clean all text if any"
+        result_flag = self.send_keys_to_element(locators.notepad_textarea, ('CONTROL', 'a'))
+        result_flag = self.send_keys_to_element(locators.notepad_textarea, ('DELETE'))
+
+        self.conditional_write(result_flag,
+            positive='Send keys to clear text',
+            negative='Failed to send keys',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def verify_text_cleared(self):
+        "Verify the text cleared"
+        text = self.get_text(locators.notepad_textarea)
+        if text == b'':
+            result_flag = True
+        else:
+            result_flag = False
+
+        self.conditional_write(result_flag,
+            positive='Verified text cleaned successfully',
+            negative='Failed to clean text',
+            level='debug')
+
+        return result_flag
+
+    def clear_text_and_verify(self):
+        "Clear text and verify it"
+        result_flag = self.clear_text_if_any()
+        result_flag &= self.verify_text_cleared()
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def enter_text(self, text):
+        "Enter the text in notepad"
+        result_flag = self.set_text(locators.notepad_textarea, text)
+        self.conditional_write(result_flag,
+            positive=f'Successfully set the text: {text}',
+            negative=f'Failed to set the text: {text}',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def verify_text_added(self, expected_text):
+        "Enter the text in notepad"
+        import unicodedata
+        result_flag = False
+        raw_text = self.get_text(locators.notepad_textarea)
+        # Decode bytes safely
+        if isinstance(raw_text, bytes):
+            decoded_text = raw_text.decode("utf-8", errors="ignore")
+        else:
+            decoded_text = str(raw_text)
+
+        # Normalize unicode (fix curly quotes, accented characters, etc.)
+        normalized_text = unicodedata.normalize("NFKC", decoded_text)
+
+        # Check substring
+        if expected_text in normalized_text:
+            result_flag = True
+
+        self.conditional_write(result_flag,
+            positive=f'verified text set correctly to: {expected_text} ',
+            negative=f'Verify text: {expected_text} not set correctly',
+            level='debug')
+
+        return result_flag
+
+    def enter_text_and_verify(self,text):
+        "Enter text and verify it"
+        result_flag = self.enter_text(text)
+        result_flag &= self.verify_text_added(text)
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def click_on_file_menu(self):
+        "Click on File menu option"
+        result_flag = self.click_element(locators.file_menu)
+        self.conditional_write(result_flag,
+            positive='Successfully clicked on file menu',
+            negative='Failed to click on file menu',
+            level='debug')
+
+        return result_flag

--- a/page_objects/examples/windows_word_app/word_home_page.py
+++ b/page_objects/examples/windows_word_app/word_home_page.py
@@ -1,0 +1,141 @@
+"""
+This class models the home page in windows word application.
+"""
+# pylint: disable = W0212,E0401
+from core_helpers.mobile_app_helper import Mobile_App_Helper
+import conf.locators_conf as locators
+from utils.Wrapit import Wrapit
+
+class WordHomePage(Mobile_App_Helper):
+    "Page objects for home page in windows word application."
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def enter_text_on_page(self, text):
+        "Enter the text in word"
+        result_flag = self.set_text(locators.word_textarea, text,clear_flag=True)
+        self.conditional_write(result_flag,
+            positive=f'Successfully set the text: {text}',
+            negative=f'Failed to set the text: {text}',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def click_on_blank_document(self):
+        "Click on blank doc option"
+        result_flag = self.click_element(locators.blank_document)
+        self.conditional_write(result_flag,
+            positive='Successfully clicked on blank doc option',
+            negative='Failed to click on blank doc option',
+            level='debug')
+
+        return result_flag
+
+    def select_blank_page_and_enter_text(self,text):
+        result_flag = self.click_on_blank_document()
+        result_flag &= self.enter_text_on_page(text)
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def click_on_insert_menu_tab(self):
+        "Click on insert menu option"
+        result_flag = self.click_element(locators.insert_tab)
+        self.conditional_write(result_flag,
+            positive='Successfully clicked on insert menu option',
+            negative='Failed to click on insert menu option',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def click_on_icons_button(self):
+        "Click on icons button"
+        result_flag = self.click_element(locators.icon_button)
+        self.conditional_write(result_flag,
+            positive='Successfully clicked on icons button',
+            negative='Failed to click on icons button',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def verify_stock_images_popup_windows(self):
+        "Click on icons button"
+        self.smart_wait(locators.stock_image_popup_window)
+        result_flag = self.check_element_displayed(locators.stock_image_popup_window)
+        self.conditional_write(result_flag,
+            positive='Stock image popup window visible',
+            negative='Stock image windows not visible',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def select_angle_face_icon(self):
+        "Select angle face icon"
+        result_flag = self.click_element(locators.icon_angel_face)
+        self.conditional_write(result_flag,
+            positive='Successfully selected angle face icon',
+            negative='Failed to select angle face icon',
+            level='debug')
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def click_on_insert_icons_button(self):
+        "Click on insert icons button"
+        result_flag = self.click_element(locators.insert_icons_button)
+        self.conditional_write(result_flag,
+            positive='Successfully clicked on insert icons button',
+            negative='Failed to click on insert icons button',
+            level='debug')
+
+        return result_flag
+
+    def insert_icon(self):
+        "insert icon"
+        result_flag = self.click_on_insert_menu_tab()
+        result_flag &= self.click_on_icons_button()
+        result_flag &= self.verify_stock_images_popup_windows()
+        result_flag &= self.select_angle_face_icon()
+        result_flag &= self.click_on_insert_icons_button()
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    @Wrapit._screenshot
+    def verify_text_on_page(self, expected_text):
+        "verify the text in word"
+        import unicodedata
+        result_flag = False
+        raw_text = self.get_text(locators.word_textarea)
+
+        # Decode bytes safely
+        if isinstance(raw_text, bytes):
+            decoded_text = raw_text.decode("utf-8", errors="ignore")
+        else:
+            decoded_text = str(raw_text)
+
+        # Normalize unicode (fix curly quotes, accented characters, etc.)
+        normalized_text = unicodedata.normalize("NFKC", decoded_text)
+
+        # Check substring
+        if expected_text in normalized_text:
+            result_flag = True
+
+        self.conditional_write(
+            result_flag,
+            positive=f"Verified the text: {expected_text} is present on page",
+            negative=f"Verified the text: {expected_text} is not present on page",
+            level='debug'
+        )
+
+        return result_flag

--- a/tests/test_notepad_app.py
+++ b/tests/test_notepad_app.py
@@ -1,0 +1,67 @@
+"""
+Automated test for windows notepad application
+Our automated test will do the following:
+    # Open the Notepad app
+    # Clear the any existing text if present and verify it
+    # Enter some text and verify it successfully entered
+    # Click on File menu 
+    # Close the app
+"""
+
+# pylint: disable=E0401, C0413
+import time
+import os
+import sys
+import pytest
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from page_objects.PageFactory import PageFactory
+
+@pytest.mark.MOBILE
+def test_notepad_app(test_windows_obj):
+    "Run the test."
+    try:
+        # Initialize flags for tests summary.
+        expected_pass = 0
+        actual_pass = -1
+
+        # # Create a test object.
+        test_windows_obj = PageFactory.get_page_object("notepad")
+        start_time = int(time.time())
+
+        # Run test steps
+        # Clear text if any and verify
+        result_flag = test_windows_obj.clear_text_and_verify()
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully cleared text if any and verified it",
+                                negative="Failed to clear text",
+                                level="critical")
+
+        #Enter text and verify
+        text = "Able to write using Qxf2's POM framework."
+        result_flag = test_windows_obj.enter_text_and_verify(text)
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully set text and verified it",
+                                negative="Failed to set text",
+                                level="critical")
+
+        #Click on File menu
+        result_flag = test_windows_obj.click_on_file_menu()
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully clicked on file menu",
+                                negative="Failed to click on file menu",
+                                level="critical")
+
+        # Print out the results.
+        test_windows_obj.write(f'Script duration: {int(time.time() - start_time)} seconds\n')
+        test_windows_obj.write_test_summary()
+
+        # Teardown and Assertion.
+        expected_pass = test_windows_obj.result_counter
+        actual_pass = test_windows_obj.pass_counter
+
+    except Exception as e:
+        print(f"Exception when trying to run test: {__file__}")
+        print(f"Python says: {str(e)}")
+
+    if expected_pass != actual_pass:
+        raise AssertionError(f"Test failed: {__file__}")

--- a/tests/test_windows_word_app.py
+++ b/tests/test_windows_word_app.py
@@ -1,0 +1,68 @@
+"""
+Automated test for windows word application
+Our automated test will do the following:
+    # Launch the MS Word app
+    # Select blank page and enter some text
+    # Insert a icon/emoji
+    # Verify page content
+    # Close the app
+
+Future Enhancement:
+    - Handle the "Save" popup that appears when closing the application
+"""
+
+# pylint: disable=E0401, C0413
+import time
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from page_objects.PageFactory import PageFactory
+
+def test_windows_word_app(test_windows_obj):
+    "Run the test."
+    try:
+        # Initialize flags for tests summary.
+        expected_pass = 0
+        actual_pass = -1
+
+        # # Create a test object.
+        test_windows_obj = PageFactory.get_page_object("word")
+        start_time = int(time.time())
+
+        # Run test steps
+        # Select blank page and enter text
+        text = "Able to write using Qxf2’s POM framework."
+        result_flag = test_windows_obj.select_blank_page_and_enter_text(text)
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully selected blank page and entered text",
+                                negative="Failed to select blank page or enter text",
+                                level="critical")
+
+        # Insert icon
+        result_flag = test_windows_obj.insert_icon()
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully inserted icon",
+                                negative="Failed to insert icon",
+                                level="critical")
+
+        #verify the text
+        result_flag = test_windows_obj.verify_text_on_page(text)
+        test_windows_obj.log_result(result_flag,
+                                positive="Successfully verified - Text is exist on page",
+                                negative="Text is missing on the page",
+                                level="critical")
+
+        # Print out the results.
+        test_windows_obj.write(f'Script duration: {int(time.time() - start_time)} seconds\n')
+        test_windows_obj.write_test_summary()
+
+        # Teardown and Assertion.
+        expected_pass = test_windows_obj.result_counter
+        actual_pass = test_windows_obj.pass_counter
+
+    except Exception as e:
+        print(f"Exception when trying to run test: {__file__}")
+        print(f"Python says: {str(e)}")
+
+    if expected_pass != actual_pass:
+        raise AssertionError(f"Test failed: {__file__}")

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals=*
 setenv= app_path= {toxinidir}/weather-shopper-app-apk/app/
 
 #Command to run the test
-commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py
+commands = python -m pytest -s -v --app_path {env:app_path} --remote_flag Y -n 3 --remote_project_name Qxf2_Selenium_POM --remote_build_name Selenium_Tutorial --junitxml=test-reports/junit.xml --tb=native --ignore=tests/test_mobile_bitcoin_price.py --ignore=tests/test_notepad_app.py --ignore=tests/test_windows_word_app.py


### PR DESCRIPTION
This update adds Windows desktop application automation capabilities to the framework.

Key Enhancements
- Integrated the Appium Windows driver
- Added page objects for Notepad and MS Word
- Added example tests for both applications to validate the automation flow
- Updated the README and wiki with Windows automation setup instructions 
- Look at Setup guide here: https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#5-setup-for-windows-automation

These additions enable automation and validation of Windows-based workflows, forming the foundation for future desktop application test coverage.

### How to Run the Sample Tests

**Notepad test:**

`pytest tests/test_notepad_app.py -s -v --win_app_full_path "C:\Windows\System32\notepad.exe"`

Refer to the below screenshot for expected console output:
<img width="1883" height="653" alt="notepad testrun 1" src="https://github.com/user-attachments/assets/0df8b580-b017-45ce-8853-6b212945e18c" />

**MS Word test:**

`pytest tests/test_windows_word_app.py -s -v`

Refer to the below screenshot for expected console output:
<img width="1896" height="722" alt="word test 1" src="https://github.com/user-attachments/assets/89952edc-efdf-47f0-a2b0-b538f4181ecb" />


