### PR TITLE
Extended framework support for CLI commands test

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,9 @@ You can use this test automation framework to write
 
 3. __Appium , WinAppDriver__ and Python scripts for __windows automation__
 
-3. __API automation__ scripts to test endpoints of your web/mobile/desktop applications
+4. __API automation__ scripts to test endpoints of your web/mobile/desktop applications
+
+5. __CLI automation__ scripts to test any cli tool or execute commands
 
 &nbsp;
 
@@ -49,6 +51,8 @@ The setup has four parts:
 3. [Setup for Mobile/Appium automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#3-setup-for-mobileappium-automation)
 4. [Setup for API automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#4-setup-for-api-automation)
 5. [Setup for Windows Automation](https://github.com/qxf2/qxf2-page-object-model/wiki/Setup#5-setup-for-windows-automation)
+6. **Setup for CLI Automation** - **Note:** No additional setup is required for CLI automation tests.
+Once the prerequisites are complete, install the CLI tool you plan to test (if needed). Otherwise, you can run the desired commands directly.  
 
 Above links redirects to our github wiki pages.
 
@@ -180,6 +184,11 @@ COMMANDS FOR RUNNING TESTS
 - **API Test**  
 	`python -m pytest tests/test_api_example.py`  
 	**Note:** Ensure the sample `cars-api` is available at `qxf2/cars-api` repository before running the API test.
+
+- **CLI Test**  
+  `python -m pytest test/test_cli_example.py`  
+  **Note:** You can use the `--cli_workdir` and `--cli_timeout` parameters to override the default settings.
+By default, `cli_workdir` is set to the root of this repository, and `cli_timeout` is set to 30 seconds.
 
 - **Mobile Test Run on Browserstack/Sauce Labs**  
 	`python -m pytest tests/test_mobile_bitcoin_price --mobile_os_version <android version> --device_name <simulator> --app_path <.apk location on local> --remote_flag Y`  

--- a/conf/cli_example_conf.py
+++ b/conf/cli_example_conf.py
@@ -1,0 +1,13 @@
+"""
+Conf file for cli example test
+"""
+
+# echo message
+echo_message = "hello-qxf2"
+
+# python version starts with 
+version_string = "python 3"
+
+# cat file and verify content
+cat_file_name="./conf/base_url_conf.py"
+cat_expected_strings=["ui_base_url", "api"]

--- a/conftest.py
+++ b/conftest.py
@@ -343,7 +343,7 @@ def test_cli_obj(cli_workdir, cli_timeout, testname):
     try:
         test_cli_obj = PageFactory.get_page_object("Zero cli")   # pylint: disable=redefined-outer-name
         test_cli_obj.set_params_and_log_file(testname,cli_workdir,cli_timeout)
-          
+
         yield test_cli_obj
 
     except Exception as e:                    # pylint: disable=broad-exception-caught

--- a/conftest.py
+++ b/conftest.py
@@ -335,6 +335,21 @@ def test_windows_obj(remote_flag, testrail_flag, tesults_flag, test_run_id, appi
                             {"action": "setSessionStatus", "arguments":
                             {"status":"failed", "reason": "Exception occured"}}""")
 
+@pytest.fixture
+def test_cli_obj(cli_workdir, cli_timeout, testname):
+    """
+    CLI helper fixture
+    """
+    try:
+        test_cli_obj = PageFactory.get_page_object("Zero cli")   # pylint: disable=redefined-outer-name
+        test_cli_obj.set_params_and_log_file(testname,cli_workdir,cli_timeout)
+          
+        yield test_cli_obj
+
+    except Exception as e:                    # pylint: disable=broad-exception-caught
+        print(Logging_Objects.color_text(f"Exception when trying to run test:{__file__}","red"))
+        print(Logging_Objects.color_text(f"Python says:{str(e)}","red"))
+
 # Fixtures for API Endpoint Auto generation unit tests
 @pytest.fixture
 def name_generator():
@@ -561,6 +576,20 @@ def snapshot_update(request):
     return request.config.getoption("--snapshot_update")
 
 @pytest.fixture
+def cli_workdir(request):
+    """
+    CLI working directory from pytest option
+    """
+    return request.config.getoption("--cli_workdir")
+
+@pytest.fixture
+def cli_timeout(request):
+    """
+    CLI command timeout from pytest option
+    """
+    return request.config.getoption("--cli_timeout")
+
+@pytest.fixture
 def reportportal_service(request):
     "pytest service fixture for reportportal"
     try:
@@ -703,6 +732,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "GUI: mark a test as part of the GUI regression suite.")
     config.addinivalue_line("markers", "API: mark a test as part of the GUI regression suite.")
     config.addinivalue_line("markers", "MOBILE: mark a test as part of the GUI regression suite.")
+    config.addinivalue_line("markers", "CLI: mark a test as part of the CLI regression suite")
 
 def pytest_terminal_summary(terminalreporter):
     "add additional section in terminal summary reporting."
@@ -947,6 +977,15 @@ def pytest_addoption(parser):
                             action="store_true",
                             default=False,
                             help="Update the snapshot instead of comparing")
+        parser.addoption("--cli_workdir",
+                            action="store",
+                            default=".",
+                            help="Working directory for executing CLI commands")
+        parser.addoption("--cli_timeout",
+                            action="store",
+                            type=int,
+                            default=30,
+                            help="Timeout (in seconds) for CLI command execution")
 
     except Exception as e:              # pylint: disable=broad-exception-caught
         print(Logging_Objects.color_text(f"Exception when trying to run test:{__file__}","red"))

--- a/core_helpers/cli_helper.py
+++ b/core_helpers/cli_helper.py
@@ -5,7 +5,6 @@ Helper class to interact with command-line tools.
 Follows the same design pattern as other helpers in core_helpers.
 """
 from .logging_objects import Logging_Objects
-#from utils import Results
 from utils.command_executor import CommandExecutor
 
 class Borg:
@@ -32,10 +31,11 @@ class CliHelper(Borg, Logging_Objects):
     def __init__(self, workdir=None, timeout=30):
         "Constructor"
         Borg.__init__(self)
+        if self.is_first_time():
+            self.reset()
+            self.msg_list = []
         self.workdir = workdir
         self.timeout = timeout
-        self.msg_list = []
-        self.reset()
 
     def reset(self):
         "Reset the base page object"

--- a/core_helpers/cli_helper.py
+++ b/core_helpers/cli_helper.py
@@ -1,0 +1,81 @@
+"""
+CLI Helper
+
+Helper class to interact with command-line tools.
+Follows the same design pattern as other helpers in core_helpers.
+"""
+from .logging_objects import Logging_Objects
+#from utils import Results
+from utils.command_executor import CommandExecutor
+
+class Borg:
+    """
+    The borg design pattern is to share state
+    #Src: http://code.activestate.com/recipes/66531/
+    """
+    __shared_state = {}
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+
+    def is_first_time(self):
+        "Has the child class been invoked before?"
+        result_flag = False
+        if len(self.__dict__)==0:
+            result_flag = True
+
+        return result_flag
+
+class CliHelper(Borg, Logging_Objects):
+    """
+    CLI helper to execute terminal commands
+    """
+    def __init__(self, workdir=None, timeout=30):
+        "Constructor"
+        Borg.__init__(self)
+        self.workdir = workdir
+        self.timeout = timeout
+        self.msg_list = []
+        self.reset()
+
+    def reset(self):
+        "Reset the base page object"
+        self.result_counter = 0 #Increment whenever success or failure are called
+        self.pass_counter = 0 #Increment everytime success is called
+        self.mini_check_counter = 0 #Increment when conditional_write is called
+        self.mini_check_pass_counter = 0 #Increment when conditional_write is called with True
+        self.failure_message_list = []
+        self.failed_scenarios = [] # <- Collect the failed scenarios for prettytable summary
+        self.screenshot_counter = 1
+        self.exceptions = []
+        self.gif_file_name = None
+        self.rp_logger = None
+        self.highlight_flag = False
+
+    def set_params_and_log_file(self,testname,workdir,timeout):
+        "set params and call set log file"
+        self.workdir = workdir
+        self.timeout = timeout
+        self.testname = testname
+        self.set_log_file()
+
+    def execute_command(self, command):
+        """
+        Execute a CLI command and return the execution result
+        """
+        return CommandExecutor.run(
+            command=command,
+            cwd=self.workdir,
+            timeout=self.timeout
+        )
+
+    def execute_command_and_verify_success(self, command):
+        """
+        Execute a CLI command and verify successful execution
+        """
+        result_flag = True
+        result = self.execute_command(command)
+
+        if result.exit_code != 0:
+            result_flag = False
+
+        return result_flag,result

--- a/core_helpers/logging_objects.py
+++ b/core_helpers/logging_objects.py
@@ -24,7 +24,7 @@ class Logging_Objects:
         }
         return f"{colors.get(color, colors['reset'])}{text}{colors['reset']}"
 
-    def write_test_summary(self):
+    def write_test_summary(self,cli_test=False):
         "Print out a useful, human readable summary"
         if self.result_counter==self.pass_counter:
             level = "success"
@@ -36,9 +36,10 @@ class Logging_Objects:
         if self.mini_check_counter > 0:
             self.write('Total number of mini-checks=%d'%self.mini_check_counter,level=level)
             self.write('Total number of mini-checks passed=%d'%self.mini_check_pass_counter,level=level)
-        self.make_gif()
-        if self.gif_file_name is not None:
-            self.write("Screenshots & GIF created at %s"%self.screenshot_dir)
+        if cli_test is False:
+            self.make_gif()
+            if self.gif_file_name is not None:
+                self.write("Screenshots & GIF created at %s"%self.screenshot_dir)
         if len(self.exceptions) > 0:
             self.exceptions = list(set(self.exceptions))
             self.write('\n--------USEFUL EXCEPTION--------\n',level="critical")
@@ -53,7 +54,7 @@ class Logging_Objects:
 
     def success(self,msg,level='success',pre_format='PASS: '):
         "Write out a success message"
-        self.log_obj.write(pre_format + msg,level)
+        self.log_obj.write(pre_format + msg + "\n",level)
         self.result_counter += 1
         self.pass_counter += 1
 
@@ -85,7 +86,7 @@ class Logging_Objects:
 
     def failure(self,msg,level='error',pre_format='FAIL: '):
         "Write out a failure message"
-        self.log_obj.write(pre_format + msg,level)
+        self.log_obj.write(pre_format + msg + "\n",level)
         self.result_counter += 1
         self.failure_message_list.append(pre_format + msg)
         if level.lower() == 'critical':
@@ -94,3 +95,19 @@ class Logging_Objects:
     def set_rp_logger(self,rp_pytest_service):
         "Set the reportportal logger"
         self.rp_logger = self.log_obj.setup_rp_logging(rp_pytest_service)
+
+    def conditional_write(self,flag,positive,negative,level='info',pre_format="  - "):
+        "Write out either the positive or the negative message based on flag"
+        self.mini_check_counter += 1
+        if level.lower() == "inverse":
+            if flag is True:
+                self.write(pre_format + positive,level='error')
+            else:
+                self.write(pre_format + negative,level='success')
+                self.mini_check_pass_counter += 1
+        else:
+            if flag is True:
+                self.write(pre_format + positive,level='success')
+                self.mini_check_pass_counter += 1
+            else:
+                self.write(pre_format + negative,level='error')

--- a/core_helpers/mobile_app_helper.py
+++ b/core_helpers/mobile_app_helper.py
@@ -114,15 +114,6 @@ class Mobile_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_O
         "Visit the page base_url + url"
         self.wait(wait_time)
 
-    def conditional_write(self,flag,positive,negative,level='debug',pre_format="  - "):
-        "Write out either the positive or the negative message based on flag"
-        if flag is True:
-            self.write(pre_format + positive,level='success')
-            self.mini_check_pass_counter += 1
-        if flag is False:
-            self.write(pre_format + negative,level='error')
-        self.mini_check_counter += 1
-
     def swipe_to_element(self,scroll_group_locator, search_element_locator, max_swipes=20, direction="up"):
         result_flag = False
         try:

--- a/core_helpers/web_app_helper.py
+++ b/core_helpers/web_app_helper.py
@@ -309,22 +309,6 @@ class Web_App_Helper(Borg, Selenium_Action_Objects, Logging_Objects, Remote_Obje
             self.write(str(e),'critical')
             return log
 
-    def conditional_write(self,flag,positive,negative,level='info'):
-        "Write out either the positive or the negative message based on flag"
-        self.mini_check_counter += 1
-        if level.lower() == "inverse":
-            if flag is True:
-                self.write(positive,level='error')
-            else:
-                self.write(negative,level='success')
-                self.mini_check_pass_counter += 1
-        else:
-            if flag is True:
-                self.write(positive,level='success')
-                self.mini_check_pass_counter += 1
-            else:
-                self.write(negative,level='error')
-
     def start(self):
         "Overwrite this method in your Page module if you want to visit a specific URL"
         pass

--- a/page_objects/PageFactory.py
+++ b/page_objects/PageFactory.py
@@ -25,6 +25,9 @@ class PageFactory():
         elif page_name in ["zero mobile","zero mobile page"]:
             from .zero_mobile_page import Zero_Mobile_Page
             test_obj = Zero_Mobile_Page()
+        elif page_name in ["zero cli","zero cli page"]:
+            from .zero_cli_page import ZeroCliPage
+            test_obj = ZeroCliPage()
         elif page_name in ["main","main page"]:
             from .examples.selenium_tutorial_webpage.tutorial_main_page import Tutorial_Main_Page
             test_obj = Tutorial_Main_Page(base_url=base_url)
@@ -62,4 +65,7 @@ class PageFactory():
         elif page_name == "notepad":
             from page_objects.examples.windows_notepad_app.notepad_home_page import NotepadHomePage
             test_obj = NotepadHomePage()
+        elif page_name == "common_cli_commands":
+            from page_objects.examples.cli_commands.common_cli_commands import CommonCliCommands
+            test_obj = CommonCliCommands()
         return test_obj

--- a/page_objects/examples/cli_commands/common_cli_commands.py
+++ b/page_objects/examples/cli_commands/common_cli_commands.py
@@ -1,0 +1,190 @@
+"""
+This class models the common cli commands.
+"""
+# pylint: disable = W0212,E0401
+from core_helpers.cli_helper import CliHelper
+from utils.Wrapit import Wrapit
+
+class CommonCliCommands(CliHelper):
+    "Page objects for the common cli commands"
+    @Wrapit._exceptionHandler
+    def execute_echo_command(self, message):
+        """
+        Execute the echo command output
+        """
+        result_flag = False
+        result = self.execute_command(["echo", message])
+        if result is not None:
+            self.write(result.stdout)
+            result_flag = True
+
+        self.conditional_write(result_flag,
+                                positive='Successfully executed echo command',
+                                negative='Failed to execute echo command')
+        return  result
+
+    @Wrapit._exceptionHandler
+    def verify_echo_response(self, result, expected_message):
+        """
+        Verify the echo command output
+        """
+        result_flag = True
+
+        if result is None:
+            result_flag = False
+            actual_output = "No result returned"
+        else:
+            actual_output = (result.stdout or "").strip()
+            expected_message = expected_message.strip()
+
+            if actual_output != expected_message:
+                result_flag = False
+
+        self.conditional_write(
+            result_flag,
+            positive=f"Echo output verified successfully: '{expected_message}'",
+            negative=(
+                f"Echo output verification failed | "
+                f"Expected: '{expected_message}' | "
+                f"Actual: '{actual_output}'"
+            )
+        )
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    def execute_echo_cmd_and_verify_response(self, message):
+        "Execute echo command and verify response"
+        result = self.execute_echo_command(message)
+
+        if result is None or result.exit_code != 0:
+            self.write("Echo command execution failed, skipping verification", level="error")
+            return False, result
+
+        result_flag = self.verify_echo_response(result, message)
+
+        return result_flag, result
+
+    @Wrapit._exceptionHandler
+    def get_python_version(self):
+        "Execute python --version command"
+        result_flag = False
+        result = self.execute_command(["python", "--version"])
+
+        if result is not None:
+            # python --version may write to stdout or stderr
+            output = result.stdout or result.stderr
+            if output:
+                self.write(output.strip())
+                result_flag = True
+
+        self.conditional_write(
+            result_flag,
+            positive='Successfully executed python version command',
+            negative='Failed to execute python version command'
+        )
+
+        return result
+
+    @Wrapit._exceptionHandler
+    def verify_python3_installed(self, result):
+        """
+        Verify python is installed and version is Python 3
+        """
+        result_flag = True
+
+        if result is None:
+            result_flag = False
+            output = "No result returned"
+        else:
+            output = (result.stdout or result.stderr or "").strip()
+
+            if result.exit_code != 0:
+                result_flag = False
+            elif not output.lower().startswith("python 3"):
+                result_flag = False
+
+        self.conditional_write(
+            result_flag,
+            positive=f"Python 3 verified successfully: {output}",
+            negative=f"Python 3 verification failed. Output: {output}"
+        )
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    def execute_python_version_cmd_and_verify(self):
+        "Execute python version command and verify Python 3 is installed"
+        result = self.get_python_version()
+
+        if result is None or result.exit_code != 0:
+            self.write("Python version command execution failed, skipping verification",
+                       level="error")
+            return False, result
+
+        result_flag = self.verify_python3_installed(result)
+
+        return result_flag, result
+
+    @Wrapit._exceptionHandler
+    def cat_file(self, file_name):
+        "Execute cat command on a given file"
+        result_flag = False
+        result = self.execute_command(["cat", file_name])
+
+        if result is not None:
+            self.write(result.stdout or result.stderr)
+            result_flag = True
+
+        self.conditional_write(
+            result_flag,
+            positive=f"Successfully executed cat command on {file_name}",
+            negative=f"Failed to execute cat command on {file_name}"
+        )
+
+        return result
+
+    @Wrapit._exceptionHandler
+    def verify_file_contains_strings(self, result, expected_strings):
+        """
+        Verify given strings are present in file content
+
+        :param result: command execution result
+        :param expected_strings: list of strings expected in file
+        """
+        result_flag = True
+
+        if result is None:
+            result_flag = False
+            output = "No result returned"
+        else:
+            output = (result.stdout or "").lower()
+
+            for expected in expected_strings:
+                if expected.lower() not in output:
+                    result_flag = False
+                    break
+
+        self.conditional_write(
+            result_flag,
+            positive=f"File contains expected entries: {expected_strings}",
+            negative=f"File does not contain expected entries: {expected_strings}"
+        )
+
+        return result_flag
+
+    @Wrapit._exceptionHandler
+    def execute_cat_file_and_verify(self, file_name, expected_strings):
+        "Execute cat command on file and verify expected content"
+        result = self.cat_file(file_name)
+
+        if result is None or result.exit_code != 0:
+            self.write(
+                f"cat command execution failed for {file_name}, skipping verification",
+                level="error"
+            )
+            return False, result
+
+        result_flag = self.verify_file_contains_strings(result, expected_strings)
+
+        return result_flag, result

--- a/page_objects/examples/cli_commands/common_cli_commands.py
+++ b/page_objects/examples/cli_commands/common_cli_commands.py
@@ -87,7 +87,7 @@ class CommonCliCommands(CliHelper):
         return result
 
     @Wrapit._exceptionHandler
-    def verify_python3_installed(self, result):
+    def verify_python3_installed(self, result,version_string):
         """
         Verify python is installed and version is Python 3
         """
@@ -101,7 +101,7 @@ class CommonCliCommands(CliHelper):
 
             if result.exit_code != 0:
                 result_flag = False
-            elif not output.lower().startswith("python 3"):
+            elif not output.lower().startswith(version_string):
                 result_flag = False
 
         self.conditional_write(
@@ -113,7 +113,7 @@ class CommonCliCommands(CliHelper):
         return result_flag
 
     @Wrapit._exceptionHandler
-    def execute_python_version_cmd_and_verify(self):
+    def execute_python_version_cmd_and_verify(self, version_string):
         "Execute python version command and verify Python 3 is installed"
         result = self.get_python_version()
 
@@ -122,7 +122,7 @@ class CommonCliCommands(CliHelper):
                        level="error")
             return False, result
 
-        result_flag = self.verify_python3_installed(result)
+        result_flag = self.verify_python3_installed(result,version_string)
 
         return result_flag, result
 

--- a/page_objects/zero_cli_page.py
+++ b/page_objects/zero_cli_page.py
@@ -1,0 +1,8 @@
+"""
+This class models the first dummy page needed by the framework to start.
+Please do not modify or delete this page
+"""
+from core_helpers.cli_helper import CliHelper
+
+class ZeroCliPage(CliHelper):
+    "Page Object for the dummy page"

--- a/tests/test_cli_example.py
+++ b/tests/test_cli_example.py
@@ -1,0 +1,71 @@
+"""
+CLI Example Tests
+
+These tests demonstrate how to use the CliHelper to execute and validate CLI commands in
+Qxf2's automation framework.
+Our automated test will do the following:
+    # Execute echo command and verify response
+    # Verify Python 3 is installed
+    # Execute cat <file> command and verify file contents
+"""
+
+import os
+import sys
+import traceback
+import pytest
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from page_objects import PageFactory
+
+
+@pytest.mark.CLI
+def test_cli_example(test_cli_obj):
+    "Run api test"
+    try:
+        expected_pass = 0
+        actual_pass = -1
+
+        # Create a test object and execute commands and verify
+        test_cli_obj = PageFactory.get_page_object("common_cli_commands")
+
+        # Execute echo command and verify response
+        result_flag, _ = test_cli_obj.execute_echo_cmd_and_verify_response("hello-qxf2")
+
+        test_cli_obj.log_result(
+            result_flag,
+            positive="Echo command executed and verified successfully",
+            negative="Echo command execution or verification failed"
+        )
+
+        # Verify python installed or not by verifing python version
+        flag, _ = test_cli_obj.execute_python_version_cmd_and_verify()
+
+        test_cli_obj.log_result(
+            flag,
+            positive="Python 3 is installed and verified",
+            negative="Python 3 is missing or incorrect version"
+        )
+
+        # cat ./conf/base_url_conf.py and verify
+        flag, _ = test_cli_obj.execute_cat_file_and_verify(file_name="./conf/base_url_conf.py",
+                                                expected_strings=["ui_base_url", "api"])
+
+        test_cli_obj.log_result(
+            flag,
+            positive="./conf/base_url_conf.py contains ui_base_url and api words",
+            negative="./conf/base_url_conf.py missing ui_base_url and/or api words"
+        )
+
+        #Print out the result
+        test_cli_obj.write_test_summary(cli_test=True)
+        expected_pass = test_cli_obj.result_counter
+        actual_pass = test_cli_obj.pass_counter
+
+    except Exception as e:
+        print(e)
+        traceback.print_exc()
+        test_cli_obj.write(f"Exception when trying to run test: {__file__}")
+        test_cli_obj.write(f"Python says: {str(e)}")
+
+    # Assertion
+    if expected_pass != actual_pass:
+        raise AssertionError(f"Test failed: {__file__}")

--- a/tests/test_cli_example.py
+++ b/tests/test_cli_example.py
@@ -15,11 +15,12 @@ import traceback
 import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from page_objects import PageFactory
+from conf import cli_example_conf as conf
 
 
 @pytest.mark.CLI
 def test_cli_example(test_cli_obj):
-    "Run api test"
+    "Run cli example test"
     try:
         expected_pass = 0
         actual_pass = -1
@@ -28,7 +29,9 @@ def test_cli_example(test_cli_obj):
         test_cli_obj = PageFactory.get_page_object("common_cli_commands")
 
         # Execute echo command and verify response
-        result_flag, _ = test_cli_obj.execute_echo_cmd_and_verify_response("hello-qxf2")
+        echo_message = conf.echo_message
+
+        result_flag, _ = test_cli_obj.execute_echo_cmd_and_verify_response(echo_message)
 
         test_cli_obj.log_result(
             result_flag,
@@ -37,7 +40,8 @@ def test_cli_example(test_cli_obj):
         )
 
         # Verify python installed or not by verifing python version
-        flag, _ = test_cli_obj.execute_python_version_cmd_and_verify()
+        version_string = conf.version_string
+        flag, _ = test_cli_obj.execute_python_version_cmd_and_verify(version_string)
 
         test_cli_obj.log_result(
             flag,
@@ -45,14 +49,17 @@ def test_cli_example(test_cli_obj):
             negative="Python 3 is missing or incorrect version"
         )
 
-        # cat ./conf/base_url_conf.py and verify
-        flag, _ = test_cli_obj.execute_cat_file_and_verify(file_name="./conf/base_url_conf.py",
-                                                expected_strings=["ui_base_url", "api"])
+        # cat file and verify content
+        cat_file_name = conf.cat_file_name
+        cat_expected_strings= conf.cat_expected_strings
+
+        flag, _ = test_cli_obj.execute_cat_file_and_verify(file_name=cat_file_name,
+                                                expected_strings=cat_expected_strings)
 
         test_cli_obj.log_result(
             flag,
-            positive="./conf/base_url_conf.py contains ui_base_url and api words",
-            negative="./conf/base_url_conf.py missing ui_base_url and/or api words"
+            positive=f"Successfully verified, file {cat_file_name} contains {cat_expected_strings} words",
+            negative=f"In file {cat_file_name} missing few or all word in the list - {cat_expected_strings}"
         )
 
         #Print out the result

--- a/utils/command_executor.py
+++ b/utils/command_executor.py
@@ -18,8 +18,16 @@ No assertions or test logic are included here by design.
 """
 
 import subprocess
+import shutil
 from dataclasses import dataclass
 from typing import Optional, List
+
+
+class UnsafeCommandError(ValueError):
+    """
+    Raised when an unsafe or invalid command is detected
+    """
+    pass
 
 
 @dataclass
@@ -39,6 +47,27 @@ class CommandExecutor:
     """
 
     @staticmethod
+    def _validate_command(command: List[str]) -> None:
+        """
+        Validate command structure and executable safety
+        """
+
+        if not isinstance(command, list) or not command:
+            raise UnsafeCommandError("Command must be a non-empty list")
+
+        for arg in command:
+            if not isinstance(arg, str):
+                raise UnsafeCommandError(
+                    "All command arguments must be strings"
+                )
+
+        executable = command[0]
+        if shutil.which(executable) is None:
+            raise UnsafeCommandError(
+                f"Executable not found in PATH: {executable}"
+            )
+
+    @staticmethod
     def run(
         command: List[str],
         cwd: Optional[str] = None,
@@ -46,7 +75,7 @@ class CommandExecutor:
         env: Optional[dict] = None
     ) -> CommandResult:
         """
-        Execute a CLI command.
+        Execute a CLI command securely.
 
         :param command: Command and arguments as list
                         Example: ["git", "--version"]
@@ -56,6 +85,9 @@ class CommandExecutor:
         :return: CommandResult object
         """
 
+        # Validate command before execution
+        CommandExecutor._validate_command(command)
+
         completed_process = subprocess.run(
             command,
             stdout=subprocess.PIPE,
@@ -63,7 +95,8 @@ class CommandExecutor:
             text=True,
             cwd=cwd,
             timeout=timeout,
-            env=env
+            env=env,
+            check=False
         )
 
         return CommandResult(
@@ -89,7 +122,6 @@ if __name__ == "__main__":
     print("\nExample 2: Command with working directory")
     print("-" * 40)
 
-    # Change this path to any directory on your machine if needed
     result = CommandExecutor.run(
         command=["git", "status"],
         cwd="."
@@ -101,25 +133,24 @@ if __name__ == "__main__":
     print(f"STDERR    : {result.stderr}")
 
 
-"""
-====================
-How to use this util
-====================
+# """
+# ====================
+# How to use this util
+# ====================
 
-1. Run directly from terminal
+# 1. Run directly from terminal
 
-python utils/command_executor.py
+# python utils/command_executor.py
 
-This will execute the examples defined under __main__.
+# This will execute the examples defined under __main__.
 
 
-2. Use inside tests or Page Objects
+# 2. Use inside tests or Page Objects
 
-from utils.command_executor import CommandExecutor
+# from utils.command_executor import CommandExecutor
 
-result = CommandExecutor.run(["git", "--version"])
+# result = CommandExecutor.run(["git", "--version"])
 
-assert result.exit_code == 0
-assert "git version" in result.stdout
-
-"""
+# assert result.exit_code == 0
+# assert "git version" in result.stdout
+# """

--- a/utils/command_executor.py
+++ b/utils/command_executor.py
@@ -1,0 +1,125 @@
+"""
+Command Executor Utility
+
+This utility provides a simple and reusable way to execute CLI commands
+from Python code and capture their response.
+
+It can be used:
+- Inside Qxf2 Page Object Model framework
+- As a standalone utility in any Python project
+
+What it captures:
+- Executed command
+- Exit code
+- Standard output (stdout)
+- Standard error (stderr)
+
+No assertions or test logic are included here by design.
+"""
+
+import subprocess
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+@dataclass
+class CommandResult:
+    """
+    Holds the result of a CLI command execution
+    """
+    command: str
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CommandExecutor:
+    """
+    Executes CLI commands and returns structured results
+    """
+
+    @staticmethod
+    def run(
+        command: List[str],
+        cwd: Optional[str] = None,
+        timeout: int = 30,
+        env: Optional[dict] = None
+    ) -> CommandResult:
+        """
+        Execute a CLI command.
+
+        :param command: Command and arguments as list
+                        Example: ["git", "--version"]
+        :param cwd: Directory in which command should be executed
+        :param timeout: Max execution time in seconds
+        :param env: Environment variables for command execution
+        :return: CommandResult object
+        """
+
+        completed_process = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            timeout=timeout,
+            env=env
+        )
+
+        return CommandResult(
+            command=" ".join(command),
+            exit_code=completed_process.returncode,
+            stdout=completed_process.stdout.strip(),
+            stderr=completed_process.stderr.strip()
+        )
+
+
+# -- START OF SCRIPT
+if __name__ == "__main__":
+    print("\nExample 1: Basic command execution")
+    print("-" * 40)
+
+    result = CommandExecutor.run(["echo", "hello-qxf2"])
+
+    print(f"Command   : {result.command}")
+    print(f"Exit Code : {result.exit_code}")
+    print(f"STDOUT    : {result.stdout}")
+    print(f"STDERR    : {result.stderr}")
+
+    print("\nExample 2: Command with working directory")
+    print("-" * 40)
+
+    # Change this path to any directory on your machine if needed
+    result = CommandExecutor.run(
+        command=["git", "status"],
+        cwd="."
+    )
+
+    print(f"Command   : {result.command}")
+    print(f"Exit Code : {result.exit_code}")
+    print(f"STDOUT    : {result.stdout}")
+    print(f"STDERR    : {result.stderr}")
+
+
+"""
+====================
+How to use this util
+====================
+
+1. Run directly from terminal
+
+python utils/command_executor.py
+
+This will execute the examples defined under __main__.
+
+
+2. Use inside tests or Page Objects
+
+from utils.command_executor import CommandExecutor
+
+result = CommandExecutor.run(["git", "--version"])
+
+assert result.exit_code == 0
+assert "git version" in result.stdout
+
+"""


### PR DESCRIPTION
This PR enhances the CLI testing support in the framework by adding reusable command execution and verification utilities, along with example tests.

Key changes:
- Added command_executor util
- Added cli_helper core helper file
- Updated conftest.py, pagefactory.py
- Added zero_cli_page and other CLI page object related to command cli object
- Updated logging_objects, web_app_helper and mobile_app_helper to improve logging_object flow
- Added new cli example test

Command to run CLI test:
` pytest tests/test_cli_example.py`

Look at run:
<img width="1888" height="790" alt="Screenshot 2026-02-04 132930" src="https://github.com/user-attachments/assets/80829d09-80a8-48ac-85d4-de70495974b1" />
