### PR TITLE
Fix Chrome driver setup for Selenium 4.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 #Add files you want to ignore
+CLAUDE.md
+**/CLAUDE.md
+memory/
 .DS_Store
 *.pyc
 *.lnk

--- a/core_helpers/drivers/local_options.py
+++ b/core_helpers/drivers/local_options.py
@@ -1,7 +1,9 @@
 """
 Get the webrivers for local browsers.
 """
+import shutil
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium import webdriver
 
 class LocalOptions():
@@ -30,7 +32,8 @@ class LocalOptions():
         """Get webdriver for chrome."""
         options = webdriver.ChromeOptions()
         options.browser_version = browser_version
-        local_driver = webdriver.Chrome(options=options)
+        service = Service(shutil.which('chromedriver'))
+        local_driver = webdriver.Chrome(service=service, options=options)
 
         return local_driver
 
@@ -57,7 +60,8 @@ class LocalOptions():
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--no-sandbox')
         options.add_argument('--ignore-certificate-errors')
-        local_driver = webdriver.Chrome(options=options)
+        service = Service(shutil.which('chromedriver'))
+        local_driver = webdriver.Chrome(service=service, options=options)
 
         return local_driver
 

--- a/core_helpers/drivers/local_options.py
+++ b/core_helpers/drivers/local_options.py
@@ -3,7 +3,9 @@ Get the webrivers for local browsers.
 """
 import shutil
 from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.firefox.service import Service as FirefoxService
+from selenium.webdriver.edge.service import Service as EdgeService
 from selenium import webdriver
 
 class LocalOptions():
@@ -14,7 +16,8 @@ class LocalOptions():
         """Get webdriver for firefox."""
         options = webdriver.FirefoxOptions()
         options.browser_version = browser_version
-        local_driver = webdriver.Firefox(options=options)
+        service = FirefoxService(shutil.which('geckodriver'))
+        local_driver = webdriver.Firefox(service=service, options=options)
 
         return local_driver
 
@@ -23,7 +26,8 @@ class LocalOptions():
         """Get webdriver for Edge."""
         options = webdriver.EdgeOptions()
         options.browser_version = browser_version
-        local_driver = webdriver.Edge(options=options)
+        service = EdgeService(shutil.which('msedgedriver'))
+        local_driver = webdriver.Edge(service=service, options=options)
 
         return local_driver
 
@@ -32,7 +36,7 @@ class LocalOptions():
         """Get webdriver for chrome."""
         options = webdriver.ChromeOptions()
         options.browser_version = browser_version
-        service = Service(shutil.which('chromedriver'))
+        service = ChromeService(shutil.which('chromedriver'))
         local_driver = webdriver.Chrome(service=service, options=options)
 
         return local_driver
@@ -60,7 +64,7 @@ class LocalOptions():
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--no-sandbox')
         options.add_argument('--ignore-certificate-errors')
-        service = Service(shutil.which('chromedriver'))
+        service = ChromeService(shutil.which('chromedriver'))
         local_driver = webdriver.Chrome(service=service, options=options)
 
         return local_driver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.32.0
 reportportal-client==5.5.4
 pytest==8.1.1
-selenium==4.12.0
+selenium==4.43.0
 python_dotenv==0.16.0
 Appium_Python_Client==3.2.0
 pytest-xdist>=1.31

--- a/utils/check_chrome_setup.py
+++ b/utils/check_chrome_setup.py
@@ -1,0 +1,36 @@
+"""
+Utility script to verify Chrome and ChromeDriver are correctly set up.
+Run this directly to confirm the browser launches before running the test suite.
+Usage: python utils/check_chrome_setup.py
+"""
+import time
+import shutil
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+
+
+def check_chrome_setup():
+    chromedriver_path = shutil.which('chromedriver')
+    if not chromedriver_path:
+        print("ERROR: chromedriver not found in PATH. Add it to your PATH and retry.")
+        return False
+
+    print("chromedriver found at: %s" % chromedriver_path)
+
+    try:
+        service = Service(chromedriver_path)
+        driver = webdriver.Chrome(service=service)
+        driver.get('https://qxf2.com/')
+        time.sleep(3)
+        print("SUCCESS: Chrome launched and qxf2.com loaded correctly.")
+        time.sleep(2)
+        driver.quit()
+        return True
+    except Exception as e:
+        print("ERROR: %s" % str(e))
+        return False
+
+
+if __name__ == '__main__':
+    check_chrome_setup()


### PR DESCRIPTION
The way we call drivers has changed with the newer seleniums. Updated code in local_options reflect that. 

Please test with Chrome, headless Chrome, Edge and Firefox. A simple test would be:
a) use the latest requirements file in this PR to update your virtualenv
b) please make sure you are using Python 3.11 or later
c) run any one web UI test on Chrome, headless Chrome, Edge and Firefox



